### PR TITLE
Add Spanish models for social media tasks

### DIFF
--- a/static/data/data_example.json
+++ b/static/data/data_example.json
@@ -1,1 +1,2680 @@
-[{"name": "BERTje", "language": "Dutch", "tasks": [{"source": "https://arxiv.org/abs/1912.09582", "code": "https://github.com/wietsedv/bertje", "name": "NER", "dataset": {"name": "CoNLL-2002", "link": "https://www.clips.uantwerpen.be/conll2002/ner/", "domain": "news"}, "measure": "F1 (test)", "performance": 88.3, "multi_lingual": 80.7, "multi_difference": 7.6}, {"name": "NER", "source": "https://arxiv.org/abs/1912.09582", "code": "https://github.com/wietsedv/bertje", "dataset": {"name": "SoNaR-1", "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus", "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"}, "measure": "F1 (test)", "performance": 82.1, "multi_lingual": 79.7, "multi_difference": 2.4}, {"name": "POS", "source": "https://arxiv.org/abs/1912.09582", "code": "https://github.com/wietsedv/bertje", "dataset": {"name": "UD-LassySmall", "link": "https://universaldependencies.org/treebanks/nl_lassysmall/index.html", "domain": "wiki"}, "measure": "Accuracy (test)", "performance": 96.3, "multi_lingual": 92.5, "multi_difference": 3.8}, {"name": "POS (C)", "source": "https://arxiv.org/abs/1912.09582", "code": "https://github.com/wietsedv/bertje", "dataset": {"name": "SoNaR-1", "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus", "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"}, "measure": "Accuracy (test)", "performance": 98.5, "multi_lingual": 98.3, "multi_difference": 0.2}, {"name": "POS (FG)", "source": "https://arxiv.org/abs/1912.09582", "code": "https://github.com/wietsedv/bertje", "dataset": {"name": "SoNaR-1", "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus", "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"}, "measure": "Accuracy (test)", "performance": 96.8, "multi_lingual": 96.2, "multi_difference": 0.6}, {"name": "SRL-PA", "source": "https://arxiv.org/abs/1912.09582", "code": "https://github.com/wietsedv/bertje", "dataset": {"name": "SoNaR-1", "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus", "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"}, "measure": "F1 (test)", "performance": 85.3, "multi_lingual": 80.4, "multi_difference": 4.9}, {"name": "SRL-M", "source": "https://arxiv.org/abs/1912.09582", "code": "https://github.com/wietsedv/bertje", "dataset": {"name": "SoNaR-1", "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus", "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"}, "measure": "F1 (test)", "performance": 67.2, "multi_lingual": 62.4, "multi_difference": 4.8}, {"name": "SRT", "source": "https://arxiv.org/abs/1912.09582", "code": "https://github.com/wietsedv/bertje", "dataset": {"name": "SoNaR-1", "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus", "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"}, "measure": "macro F1 (test)", "performance": 64.3, "multi_lingual": 57.3, "multi_difference": 7.0}, {"name": "SA", "source": "https://arxiv.org/abs/1912.09582", "code": "https://github.com/wietsedv/bertje", "dataset": {"name": "110k Dutch Book Reviews Dataset", "link": "https://benjaminvdb.github.io/110kDBRD/", "domain": "book Reviews"}, "measure": "Accuracy (test)", "performance": 93.0, "multi_lingual": 89.1, "multi_difference": 3.9}, {"name": "DDD", "source": "https://arxiv.org/abs/2001.06286", "code": "https://github.com/iPieter/RobBERT", "dataset": {"name": "Europarl", "link": "https://www.statmt.org/europarl/", "domain": "proceedings"}, "measure": "Accuracy (test)", "performance": 98.27, "multi_lingual": 98.28, "multi_difference": -0.01}]}, {"name": "RobBERT", "language": "Dutch", "tasks": [{"source": "https://arxiv.org/abs/2001.06286", "code": "https://github.com/iPieter/RobBERT", "name": "SA", "dataset": {"name": "110k Dutch Book Reviews Dataset", "link": "https://benjaminvdb.github.io/110kDBRD/", "domain": "book Reviews"}, "measure": "Accuracy (test)", "performance": 94.42, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "DDD", "source": "https://arxiv.org/abs/2001.06286", "code": "https://github.com/iPieter/RobBERT", "dataset": {"name": "Europarl", "link": "https://www.statmt.org/europarl/", "domain": "proceedings"}, "measure": "Accuracy (test)", "performance": 98.41, "multi_lingual": 98.28, "multi_difference": 0.13}]}, {"name": "CamemBERT", "language": "French", "tasks": [{"source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "name": "POS", "dataset": {"name": "GSD", "link": "https://github.com/ryanmcd/uni-dep-tb", "domain": "blogs, news, reviews, wiki"}, "measure": "UPOS", "performance": 98.19, "multi_lingual": 97.48, "multi_difference": 0.71}, {"name": "DP-UAS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "GSD", "link": "https://github.com/ryanmcd/uni-dep-tb", "domain": "blogs, news, reviews, wiki"}, "measure": "Accuracy (test)", "performance": 94.82, "multi_lingual": 92.72, "multi_difference": 2.1}, {"name": "DP-LAS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "GSD", "link": "https://github.com/ryanmcd/uni-dep-tb", "domain": "blogs, news, reviews, wiki"}, "measure": "Accuracy (test)", "performance": 92.47, "multi_lingual": 89.73, "multi_difference": 2.74}, {"name": "POS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "Sequoia", "link": "https://deep-sequoia.inria.fr/", "domain": "politics, news, wiki, agency"}, "measure": "UPOS", "performance": 99.21, "multi_lingual": 98.41, "multi_difference": 0.8}, {"name": "DP-UAS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "Sequoia", "link": "https://deep-sequoia.inria.fr/", "domain": "politics, news, wiki, agency"}, "measure": "Accuracy (test)", "performance": 95.56, "multi_lingual": 93.24, "multi_difference": 2.32}, {"name": "DP-LAS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "Sequoia", "link": "https://deep-sequoia.inria.fr/", "domain": "politics, news, wiki, agency"}, "measure": "Accuracy (test)", "performance": 94.39, "multi_lingual": 91.24, "multi_difference": 3.15}, {"name": "POS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "Spoken", "link": "https://www.projet-rhapsodie.fr/", "domain": "transcription"}, "measure": "UPOS", "performance": 96.68, "multi_lingual": 96.02, "multi_difference": 0.66}, {"name": "DP-UAS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "Spoken", "link": "https://www.projet-rhapsodie.fr/", "domain": "transcription"}, "measure": "Accuracy (test)", "performance": 86.05, "multi_lingual": 84.65, "multi_difference": 1.4}, {"name": "DP-LAS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "Spoken", "link": "https://www.projet-rhapsodie.fr/", "domain": "transcription"}, "measure": "Accuracy (test)", "performance": 80.07, "multi_lingual": 78.63, "multi_difference": 1.44}, {"name": "POS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "ParTUT", "link": "http://www.di.unito.it/~tutreeb/treebanks.html", "domain": "legal, license, misc"}, "measure": "UPOS", "performance": 97.63, "multi_lingual": 97.35, "multi_difference": 0.28}, {"name": "DP-UAS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "ParTUT", "link": "http://www.di.unito.it/~tutreeb/treebanks.html", "domain": "legal, license, misc"}, "measure": "Accuracy (test)", "performance": 95.21, "multi_lingual": 94.18, "multi_difference": 1.03}, {"name": "DP-LAS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "ParTUT", "link": "http://www.di.unito.it/~tutreeb/treebanks.html", "domain": "legal, license, misc"}, "measure": "Accuracy (test)", "performance": 92.2, "multi_lingual": 91.37, "multi_difference": 0.83}, {"name": "POS", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "French Treebank", "link": "http://ftb.linguist.univ-paris-diderot.fr/telecharger.php?langue=en", "domain": "news"}, "measure": "F1", "performance": 87.93, "multi_lingual": 82.75, "multi_difference": 5.18}, {"name": "NLI", "source": "https://arxiv.org/abs/1911.03894", "code": "https://camembert-model.fr/", "dataset": {"name": "XNLI (French)", "link": "https://github.com/facebookresearch/XNLI", "domain": "transcription, politics, news, literature, misc"}, "measure": "Accuracy", "performance": 81.2, "multi_lingual": 76.9, "multi_difference": 4.3}, {"name": "SA", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "CLS (French)", "link": "https://webis.de/data/webis-cls-10.html", "domain": "book reviews"}, "measure": "Accuracy", "performance": 93.4, "multi_lingual": 86.15, "multi_difference": 7.25}, {"name": "SA", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "CLS (French)", "link": "https://webis.de/data/webis-cls-10.html", "domain": "dvd reviews"}, "measure": "Accuracy", "performance": 92.7, "multi_lingual": 86.9, "multi_difference": 5.8}, {"name": "SA", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "CLS (French)", "link": "https://webis.de/data/webis-cls-10.html", "domain": "music reviews"}, "measure": "Accuracy", "performance": 94.15, "multi_lingual": 86.65, "multi_difference": 7.5}, {"name": "PI", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "PAWS-X (French)", "link": "https://github.com/google-research-datasets/paws", "domain": "wiki"}, "measure": "Accuracy", "performance": 89.8, "multi_lingual": 89.3, "multi_difference": 0.5}, {"name": "POS", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "French Treebank", "link": "http://ftb.linguist.univ-paris-diderot.fr/telecharger.php?langue=en", "domain": "news"}, "measure": "F1 (test)", "performance": 88.39, "multi_lingual": 87.52, "multi_difference": 0.87}, {"name": "VSD", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "FrenchSemeval", "link": "http://www.llf.cnrs.fr/dataset/fse/", "domain": "wiki"}, "measure": "F1", "performance": 51.9, "multi_lingual": 44.93, "multi_difference": 6.97}, {"name": "NSD", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "Semeval 2013 Task 12 (French)", "link": "https://www.cs.york.ac.uk/semeval-2013/", "domain": "news"}, "measure": "F1", "performance": 51.52, "multi_lingual": 53.48, "multi_difference": -1.96}]}, {"name": "FlauBERT", "language": "French", "tasks": [{"source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "name": "SA", "dataset": {"name": "CLS (French)", "link": "https://webis.de/data/webis-cls-10.html", "domain": "book reviews"}, "measure": "Accuracy", "performance": 93.4, "multi_lingual": 86.15, "multi_difference": 7.25}, {"name": "SA", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "CLS (French)", "link": "https://webis.de/data/webis-cls-10.html", "domain": "dvd reviews"}, "measure": "Accuracy", "performance": 92.5, "multi_lingual": 86.9, "multi_difference": 5.6}, {"name": "SA", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "CLS (French)", "link": "https://webis.de/data/webis-cls-10.html", "domain": "music reviews"}, "measure": "Accuracy", "performance": 94.3, "multi_lingual": 86.65, "multi_difference": 7.65}, {"name": "PI", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "PAWS-X (French)", "link": "https://github.com/google-research-datasets/paws", "domain": "wiki"}, "measure": "Accuracy", "performance": 89.9, "multi_lingual": 89.3, "multi_difference": 0.6}, {"name": "NLI", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "XNLI", "link": "https://github.com/facebookresearch/XNLI", "domain": "transcription, politics, news, literature, misc"}, "measure": "Accuracy", "performance": 81.3, "multi_lingual": 76.9, "multi_difference": 4.4}, {"name": "NER", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "French Treebank", "link": "http://ftb.linguist.univ-paris-diderot.fr/telecharger.php?langue=en", "domain": "news"}, "measure": "F1 (test)", "performance": 89.05, "multi_lingual": 87.52, "multi_difference": 1.53}, {"name": "VSD", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "FrenchSemeval", "link": "http://www.llf.cnrs.fr/dataset/fse/", "domain": "wiki"}, "measure": "F1", "performance": 47.4, "multi_lingual": 44.93, "multi_difference": 2.47}, {"name": "NSD", "source": "https://arxiv.org/abs/1912.05372", "code": "https://github.com/getalp/Flaubert", "dataset": {"name": "Semeval 2013 Task 12 (French)", "link": "https://www.cs.york.ac.uk/semeval-2013/", "domain": "news"}, "measure": "F1", "performance": 50.78, "multi_lingual": 53.48, "multi_difference": -2.7}]}, {"name": "FinBERT", "language": "Finnish", "tasks": [{"source": "https://arxiv.org/abs/1912.07076", "code": "http://turkunlp.org/FinBERT/", "name": "POS", "dataset": {"name": "Turku Dependency Treebank", "link": "https://turkunlp.org/finnish_nlp.html#treebank", "domain": "wiki, news, blog, speech, legislative, fiction"}, "measure": "UPOS", "performance": 98.23, "multi_lingual": 96.97, "multi_difference": 1.26}, {"name": "POS", "source": "https://arxiv.org/abs/1912.07076", "code": "http://turkunlp.org/FinBERT/", "dataset": {"name": "FinnTreeBank", "link": "http://www.ling.helsinki.fi/kieliteknologia/tutkimus/treebank/index-print.shtml", "domain": "grammar, news, literature, politics, legislative, misc"}, "measure": "UPOS", "performance": 98.39, "multi_lingual": 95.87, "multi_difference": 2.52}, {"name": "POS", "source": "https://arxiv.org/abs/1912.07076", "code": "http://turkunlp.org/FinBERT/", "dataset": {"name": "Parallel UD treebank", "link": "http://universaldependencies.org/conll17/data.html", "domain": "wiki, news"}, "measure": "UPOS", "performance": 98.08, "multi_lingual": 97.58, "multi_difference": 0.5}, {"name": "NER", "source": "https://arxiv.org/abs/1912.07076", "code": "http://turkunlp.org/FinBERT/", "dataset": {"name": "FiNER", "link": "http://metashare.csc.fi/repository/browse/finnish-news-corpus-for-named-entity-recognition/a10cea3c69ef11e9b99d005056be118e9c015616f4294cd9af85b019714ffb3c/", "domain": "wiki, news"}, "measure": "F1", "performance": 92.4, "multi_lingual": 90.29, "multi_difference": 2.11}, {"name": "DP", "source": "https://arxiv.org/abs/1912.07076", "code": "http://turkunlp.org/FinBERT/", "dataset": {"name": "Turku Dependency Treebank", "link": "https://turkunlp.org/finnish_nlp.html#treebank", "domain": "wiki, news, blog, speech, legislative, fiction"}, "measure": "LAS (predicted segmentation)", "performance": 91.93, "multi_lingual": 86.32, "multi_difference": 5.61}, {"name": "DP", "source": "https://arxiv.org/abs/1912.07076", "code": "http://turkunlp.org/FinBERT/", "dataset": {"name": "FinnTreeBank", "link": "http://www.ling.helsinki.fi/kieliteknologia/tutkimus/treebank/index-print.shtml", "domain": "grammar, news, literature, politics, legislative, misc"}, "measure": "LAS (predicted segmentation)", "performance": 92.16, "multi_lingual": 85.52, "multi_difference": 6.64}, {"name": "DP", "source": "https://arxiv.org/abs/1912.07076", "code": "http://turkunlp.org/FinBERT/", "dataset": {"name": "Parallel UD treebank", "link": "http://universaldependencies.org/conll17/data.html", "domain": "wiki, news"}, "measure": "LAS (predicted segmentation)", "performance": 92.54, "multi_lingual": 89.18, "multi_difference": 3.36}, {"name": "TC", "source": "https://arxiv.org/abs/1912.07076", "code": "http://turkunlp.org/FinBERT/", "dataset": {"name": "Yle news", "link": "https://github.com/spyysalo/yle-corpus", "domain": "news"}, "measure": "Accuracy (test size 10K)", "performance": 90.57, "multi_lingual": 88.44, "multi_difference": 2.13}, {"name": "TC", "source": "https://arxiv.org/abs/1912.07076", "code": "http://turkunlp.org/FinBERT/", "dataset": {"name": "Ylilauta online discussion", "link": "https://github.com/spyysalo/ylilauta-corpus", "domain": "social"}, "measure": "Accuracy (test size 10K)", "performance": 79.18, "multi_lingual": 67.92, "multi_difference": 11.26}]}, {"name": "Italian BERT (XXL)", "language": "Italian", "tasks": [{"source": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md", "code": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md", "name": "NER", "dataset": {"name": "WikiNER", "link": "https://github.com/dice-group/FOX/tree/master/input/Wikiner", "domain": "wiki"}, "measure": "F1 (test)", "performance": 93.61, "multi_lingual": 93.53, "multi_difference": 0.08}, {"name": "NER", "source": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md", "code": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md", "dataset": {"name": "I-CAB 2009", "link": "http://ontotext.fbk.eu/icab.html", "domain": "news"}, "measure": "F1", "performance": 88.13, "multi_lingual": 85.18, "multi_difference": 2.95}, {"name": "POS", "source": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md", "code": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md", "dataset": {"name": "PoSTWITA", "link": "http://www.evalita.it/2016/tasks/postwita", "domain": "twitter"}, "measure": "Accuracy", "performance": 93.75, "multi_lingual": 91.54, "multi_difference": 2.21}]}, {"name": "ALBERTO", "language": "Italian", "tasks": [{"source": "http://ceur-ws.org/Vol-2481/paper57.pdf", "code": "https://github.com/marcopoli/AlBERTo-it", "name": "SA", "dataset": {"name": "SENTIPOLC 2016", "link": "http://www.di.unito.it/~tutreeb/sentipolc-evalita16/data.html", "domain": "twitter"}, "measure": "F1 (test)", "performance": 72.23, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SC", "source": "http://ceur-ws.org/Vol-2481/paper57.pdf", "code": "https://github.com/marcopoli/AlBERTo-it", "dataset": {"name": "SENTIPOLC 2016", "link": "http://www.di.unito.it/~tutreeb/sentipolc-evalita16/data.html", "domain": "twitter"}, "measure": "F1 (test)", "performance": 79.06, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "ID", "source": "http://ceur-ws.org/Vol-2481/paper57.pdf", "code": "https://github.com/marcopoli/AlBERTo-it", "dataset": {"name": "SENTIPOLC 2016", "link": "http://www.di.unito.it/~tutreeb/sentipolc-evalita16/data.html", "domain": "twitter"}, "measure": "F1 (test)", "performance": 60.9, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "Gilberto", "language": "Italian", "tasks": [{"source": "https://github.com/idb-ita/GilBERTo", "code": "https://github.com/idb-ita/GilBERTo", "name": "POS", "dataset": {"name": "ParTUT", "link": "http://www.di.unito.it/~tutreeb/treebanks.html", "domain": "legal, license, misc"}, "measure": "UPOS", "performance": 98.8, "multi_lingual": 98.0, "multi_difference": 0.8}, {"name": "POS", "source": "https://github.com/idb-ita/GilBERTo", "code": "https://github.com/idb-ita/GilBERTo", "dataset": {"name": "ISDT", "link": "https://github.com/UniversalDependencies/UD_Italian-ISDT", "domain": "legal, news, wiki, misc"}, "measure": "UPOS", "performance": 98.6, "multi_lingual": 98.5, "multi_difference": 0.1}, {"name": "NER", "source": "https://github.com/idb-ita/GilBERTo", "code": "https://github.com/idb-ita/GilBERTo", "dataset": {"name": "WikiNER", "link": "https://github.com/dice-group/FOX/tree/master/input/Wikiner", "domain": "wiki"}, "measure": "F1", "performance": 92.7, "multi_lingual": 92.2, "multi_difference": 0.5}]}, {"name": "Umberto", "language": "Italian", "tasks": [{"source": "https://github.com/musixmatchresearch/umberto", "code": "https://github.com/musixmatchresearch/umberto", "name": "POS", "dataset": {"name": "ParTUT", "link": "http://www.di.unito.it/~tutreeb/treebanks.html", "domain": "legal, license, misc"}, "measure": "Accuracy", "performance": 98.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "POS", "source": "https://github.com/musixmatchresearch/umberto", "code": "https://github.com/musixmatchresearch/umberto", "dataset": {"name": "ISDT", "link": "https://github.com/UniversalDependencies/UD_Italian-ISDT", "domain": "legal, news, wiki, misc"}, "measure": "Accuracy", "performance": 98.98, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "NER", "source": "https://github.com/musixmatchresearch/umberto", "code": "https://github.com/musixmatchresearch/umberto", "dataset": {"name": "WikiNER", "link": "https://github.com/dice-group/FOX/tree/master/input/Wikiner", "domain": "wiki"}, "measure": "F1", "performance": 92.53, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "NER", "source": "https://github.com/musixmatchresearch/umberto", "code": "https://github.com/musixmatchresearch/umberto", "dataset": {"name": "I-CAB 2007", "link": "http://ontotext.fbk.eu/icab.html", "domain": "news"}, "measure": "F1", "performance": 92.53, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "deepset-GermanBERT", "language": "German", "tasks": [{"source": "https://deepset.ai/german-bert", "code": "https://deepset.ai/german-bert", "name": "IOL", "dataset": {"name": "germEval18Fine", "link": "https://github.com/uds-lsv/GermEval-2018-Data", "domain": "twitter"}, "measure": "F1", "performance": 74.7, "multi_lingual": 71.0, "multi_difference": 3.7}, {"name": "IOL", "source": "https://deepset.ai/german-bert", "code": "https://deepset.ai/german-bert", "dataset": {"name": "germEval18coarse", "link": "https://github.com/uds-lsv/GermEval-2018-Data", "domain": "twitter"}, "measure": "F1", "performance": 48.8, "multi_lingual": 44.1, "multi_difference": 4.7}, {"name": "NER", "source": "https://deepset.ai/german-bert", "code": "https://deepset.ai/german-bert", "dataset": {"name": "germEval14", "link": "https://sites.google.com/site/germeval2014ner/data", "domain": "wiki, news"}, "measure": "F1", "performance": 84.0, "multi_lingual": 83.4, "multi_difference": 0.6}, {"name": "NER", "source": "https://deepset.ai/german-bert", "code": "https://deepset.ai/german-bert", "dataset": {"name": "CoNLL-2003", "link": "https://github.com/MaviccPRP/ger_ner_evals/tree/master/corpora/conll2003", "domain": "news"}, "measure": "F1", "performance": 80.4, "multi_lingual": 79.2, "multi_difference": 1.2}, {"name": "TC", "source": "https://deepset.ai/german-bert", "code": "https://deepset.ai/german-bert", "dataset": {"name": "10kGNAD", "link": "https://github.com/tblock/10kGNAD", "domain": "news"}, "measure": "Accuracy", "performance": 90.5, "multi_lingual": 88.8, "multi_difference": 1.7}, {"name": "NER", "source": "https://github.com/dbmdz/berts/blob/master/README.md", "code": "https://github.com/dbmdz/berts/blob/master/README.md", "dataset": {"name": "CoNLL-2003", "link": "https://github.com/MaviccPRP/ger_ner_evals/tree/master/corpora/conll2003", "domain": "news"}, "measure": "F1 (test)", "performance": 83.7, "multi_lingual": 82.55, "multi_difference": 1.15}, {"name": "NER", "source": "https://github.com/dbmdz/berts/blob/master/README.md", "code": "https://github.com/dbmdz/berts/blob/master/README.md", "dataset": {"name": "germEval14", "link": "https://sites.google.com/site/germeval2014ner/data", "domain": "wiki, news"}, "measure": "F1 (test)", "performance": 86.61, "multi_lingual": 86.26, "multi_difference": 0.35}, {"name": "POS", "source": "https://github.com/dbmdz/berts/blob/master/README.md", "code": "https://github.com/dbmdz/berts/blob/master/README.md", "dataset": {"name": "Parallel UD treebank", "link": "https://universaldependencies.org/treebanks/de_hdt/index.html", "domain": "wiki, news"}, "measure": "Accuracy (test)", "performance": 98.56, "multi_lingual": 98.58, "multi_difference": -0.02}]}, {"name": "German BERT", "language": "German", "tasks": [{"source": "https://github.com/dbmdz/berts/blob/master/README.md", "code": "https://github.com/dbmdz/berts/blob/master/README.md", "name": "POS", "dataset": {"name": "Parallel UD treebank", "link": "https://universaldependencies.org/treebanks/de_hdt/index.html", "domain": "wiki, news"}, "measure": "Accuracy (test)", "performance": 98.57, "multi_lingual": 98.58, "multi_difference": -0.01}, {"name": "NER", "source": "https://github.com/dbmdz/berts/blob/master/README.md", "code": "https://github.com/dbmdz/berts/blob/master/README.md", "dataset": {"name": "germEval14", "link": "https://sites.google.com/site/germeval2014ner/data", "domain": "wiki, news"}, "measure": "F1 (test)", "performance": 86.89, "multi_lingual": 86.26, "multi_difference": 0.63}, {"name": "NER", "source": "https://github.com/dbmdz/berts/blob/master/README.md", "code": "https://github.com/dbmdz/berts/blob/master/README.md", "dataset": {"name": "CoNLL-2003", "link": "https://github.com/MaviccPRP/ger_ner_evals/tree/master/corpora/conll2003", "domain": "news"}, "measure": "F1 (test)", "performance": 84.52, "multi_lingual": 82.55, "multi_difference": 1.97}]}, {"name": "German Europeana BERT", "language": "German", "tasks": [{"source": "https://github.com/dbmdz/berts/blob/master/README.md#german-europeana-bert", "code": "https://github.com/dbmdz/berts/blob/master/README.md#german-europeana-bert", "name": "NER", "dataset": {"name": "LFT", "link": "https://github.com/KBNLresearch/europeananp-ner/", "domain": "news"}, "measure": "F1", "performance": 80.55, "multi_lingual": 77.26, "multi_difference": 3.29}, {"name": "NER", "source": "https://github.com/dbmdz/berts/blob/master/README.md#german-europeana-bert", "code": "https://github.com/dbmdz/berts/blob/master/README.md#german-europeana-bert", "dataset": {"name": "ONB ", "link": "https://github.com/KBNLresearch/europeananp-ner/", "domain": "news"}, "measure": "F1", "performance": 85.5, "multi_lingual": 83.44, "multi_difference": 2.06}]}, {"name": "BETO", "language": "Spanish", "tasks": [{"source": "https://github.com/dccuchile/beto", "code": "https://github.com/dccuchile/beto", "name": "POS", "dataset": {"name": "Turku Dependency Treebank", "link": "https://lindat.mff.cuni.cz/repository/xmlui/handle/11234/1-1827", "domain": "wiki, news, blog, speech, legislative, fiction"}, "measure": "UPOS", "performance": 98.97, "multi_lingual": 97.1, "multi_difference": 1.87}, {"name": "NER", "source": "https://github.com/dccuchile/beto", "code": "https://github.com/dccuchile/beto", "dataset": {"name": "CoNLL 2000, 2002, 2007", "link": "https://www.kaggle.com/nltkdata/conll-corpora", "domain": "news"}, "measure": "F1", "performance": 88.43, "multi_lingual": 87.38, "multi_difference": 1.05}, {"name": "TC", "source": "https://github.com/dccuchile/beto", "code": "https://github.com/dccuchile/beto", "dataset": {"name": "MLDoc", "link": "https://github.com/facebookresearch/MLDoc", "domain": "news"}, "measure": "Accuracy", "performance": 95.6, "multi_lingual": 95.7, "multi_difference": -0.1}, {"name": "PI", "source": "https://github.com/dccuchile/beto", "code": "https://github.com/dccuchile/beto", "dataset": {"name": "PAWS-X", "link": "https://github.com/google-research-datasets/paws/tree/master/pawsx", "domain": "wiki"}, "measure": "Accuracy", "performance": 89.05, "multi_lingual": 90.7, "multi_difference": -1.65}, {"name": "NLI", "source": "https://github.com/dccuchile/beto", "code": "https://github.com/dccuchile/beto", "dataset": {"name": "XNLI", "link": "https://github.com/facebookresearch/XNLI", "domain": "transcription, politics, news, literature, misc"}, "measure": "Accuracy", "performance": 82.01, "multi_lingual": 78.5, "multi_difference": 3.51}]}, {"name": "RuBERT", "language": "Russian", "tasks": [{"source": "https://drive.google.com/open?id=1wAe9MjwQ3QYEtrsiQt0BKL6INQ_J2WAo", "code": NaN, "name": "PI", "dataset": {"name": "Paraphraser", "link": "http://paraphraser.ru/download/", "domain": "news"}, "measure": "Accuracy", "performance": 84.99, "multi_lingual": 81.66, "multi_difference": 3.33}, {"name": "SA", "source": "https://drive.google.com/open?id=1wAe9MjwQ3QYEtrsiQt0BKL6INQ_J2WAo", "code": NaN, "dataset": {"name": "RuSentiment", "link": "http://text-machine.cs.uml.edu/projects/rusentiment/", "domain": "social"}, "measure": "F1", "performance": 72.63, "multi_lingual": 70.82, "multi_difference": 1.81}, {"name": "QA", "source": "https://drive.google.com/open?id=1wAe9MjwQ3QYEtrsiQt0BKL6INQ_J2WAo", "code": NaN, "dataset": {"name": "SDSJ Task B", "link": "https://sdsj.sberbank.ai/2017/en/contest.html", "domain": "wiki"}, "measure": "F1 (dev)", "performance": 84.6, "multi_lingual": 83.39, "multi_difference": 1.21}]}, {"name": "SlavicBERT", "language": "Slavic", "tasks": [{"source": "https://github.com/deepmipt/Slavic-BERT-NER", "code": "https://github.com/deepmipt/Slavic-BERT-NER", "name": "NER", "dataset": {"name": "BSNLP-2019 dataset", "link": "http://bsnlp.cs.helsinki.fi/shared_task.html", "domain": "web"}, "measure": "Recall", "performance": 91.8, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "Ch-RoBERTa-wwm-ext-large", "language": "Chinese", "tasks": [{"source": "https://arxiv.org/abs/1906.08101", "code": "https://github.com/ymcui/Chinese-BERT-wwm", "name": "MRC", "dataset": {"name": "CMRC 2018", "link": "https://github.com/ymcui/cmrc2018", "domain": "wiki"}, "measure": "F1 (test)", "performance": 90.0, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "MRC", "source": "https://arxiv.org/abs/1906.08101", "code": "https://github.com/ymcui/Chinese-BERT-wwm", "dataset": {"name": "DRCD", "link": "https://github.com/DRCKnowledgeTeam/DRCD", "domain": "wiki"}, "measure": "F1 (test)", "performance": 94.1, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "MRC", "source": "https://arxiv.org/abs/1906.08101", "code": "https://github.com/ymcui/Chinese-BERT-wwm", "dataset": {"name": "CJRC", "link": NaN, "domain": "law"}, "measure": "F1 (test)", "performance": 81.0, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "NLI", "source": "https://arxiv.org/abs/1906.08101", "code": "https://github.com/ymcui/Chinese-BERT-wwm", "dataset": {"name": "XNLI", "link": "https://github.com/facebookresearch/XNLI", "domain": "transcription, politics, news, literature, misc"}, "measure": "Accuracy (test)", "performance": 80.6, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SA", "source": "https://arxiv.org/abs/1906.08101", "code": "https://github.com/ymcui/Chinese-BERT-wwm", "dataset": {"name": "ChnSentiCorpz", "link": "https://github.com/pengming617/bert_classification", "domain": "social, misc"}, "measure": "Accuracy (test)", "performance": 94.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SPM", "source": "https://arxiv.org/abs/1906.08101", "code": "https://github.com/ymcui/Chinese-BERT-wwm", "dataset": {"name": "LCQMC", "link": "http://icrc.hitsz.edu.cn/Article/show/171.html", "domain": "social"}, "measure": "Accuracy (test)", "performance": 86.8, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SPM", "source": "https://arxiv.org/abs/1906.08101", "code": "https://github.com/ymcui/Chinese-BERT-wwm", "dataset": {"name": "BQ Corpus", "link": "http://icrc.hitsz.edu.cn/Article/show/175.html", "domain": "log"}, "measure": "Accuracy (test)", "performance": 84.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "TC", "source": "https://arxiv.org/abs/1906.08101", "code": "https://github.com/ymcui/Chinese-BERT-wwm", "dataset": {"name": "THUCNews", "link": "https://github.com/gaussic/text-classification-cnn-rnn", "domain": "news"}, "measure": "Accuracy (test)", "performance": 97.6, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "BERT Japanese", "language": "Japanese", "tasks": [{"source": "https://github.com/yoheikikuta/bert-japanese", "code": "https://github.com/yoheikikuta/bert-japanese", "name": "TC", "dataset": {"name": "Livedoor", "link": "https://www.rondhuit.com/download.html", "domain": "news"}, "measure": "F1 (macro)", "performance": 97.0, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "KoBERT", "language": "Korean", "tasks": [{"source": "https://github.com/SKTBrain/KoBERT", "code": "https://github.com/SKTBrain/KoBERT#korean-bert-pre-trained-cased-kobert", "name": "SA", "dataset": {"name": "Naver", "link": "https://github.com/e9t/nsmc", "domain": "movie review"}, "measure": "Accuracy", "performance": 90.1, "multi_lingual": 87.5, "multi_difference": 2.6}]}, {"name": "BERT-th", "language": "Thai", "tasks": [{"source": "https://github.com/ThAIKeras/bert", "code": "https://github.com/ThAIKeras/bert", "name": "NLI", "dataset": {"name": "XNLI", "link": "https://github.com/facebookresearch/XNLI", "domain": "transcription, politics, news, literature, misc"}, "measure": "Accuracy", "performance": 68.9, "multi_lingual": 66.1, "multi_difference": 2.8}, {"name": "SA", "source": "https://github.com/ThAIKeras/bert", "code": "https://github.com/ThAIKeras/bert", "dataset": {"name": "Wongnai Review Dataset", "link": "https://github.com/wongnai/wongnai-corpus", "domain": "restaurant reviews"}, "measure": "Accuracy", "performance": 57.06, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "Mongolian BERT", "language": "Mongolian", "tasks": [{"source": "https://github.com/tugstugi/mongolian-bert", "code": "https://github.com/tugstugi/mongolian-bert", "name": "NER", "dataset": {"name": "Mongolian NER", "link": "https://github.com/tugstugi/mongolian-nlp/blob/master/datasets/NER_v1.0.json.gz", "domain": "news"}, "measure": "F1 (test)", "performance": 81.46, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "BERTurk", "language": "Turkish", "tasks": [{"source": "https://github.com/stefan-it/turkish-bert", "code": "https://github.com/stefan-it/turkish-bert", "name": "POS", "dataset": {"name": "IMST dataset", "link": "https://github.com/UniversalDependencies/UD_Turkish-IMST", "domain": "misc"}, "measure": "Accuracy", "performance": 96.93, "multi_lingual": 95.38, "multi_difference": 1.55}, {"name": "NER", "source": "https://github.com/stefan-it/turkish-bert", "code": "https://github.com/stefan-it/turkish-bert", "dataset": {"name": NaN, "link": NaN, "domain": NaN}, "measure": "F1", "performance": 94.85, "multi_lingual": 93.61, "multi_difference": 1.24}]}, {"name": "Arabert v1", "language": "Arabic", "tasks": [{"source": "https://arxiv.org/abs/2003.00104", "code": "https://github.com/aub-mind/arabert", "name": "SA", "dataset": {"name": "AJGT", "link": "https://github.com/komari6/Arabic-twitter-corpus-AJGT", "domain": "twitter"}, "measure": "Accuracy", "performance": 93.8, "multi_lingual": 83.6, "multi_difference": 10.2}, {"name": "SA", "source": "https://arxiv.org/abs/2003.00104", "code": "https://github.com/aub-mind/arabert", "dataset": {"name": "HARD", "link": "https://github.com/elnagara/HARD-Arabic-Dataset", "domain": "hotel reviews"}, "measure": "Accuracy", "performance": 96.1, "multi_lingual": 95.7, "multi_difference": 0.4}, {"name": "SA", "source": "https://arxiv.org/abs/2003.00104", "code": "https://github.com/aub-mind/arabert", "dataset": {"name": "ASTD", "link": "http://www.mohamedaly.info/datasets/astd", "domain": "twitter"}, "measure": "Accuracy", "performance": 92.6, "multi_lingual": 80.1, "multi_difference": 12.5}, {"name": "SA", "source": "https://arxiv.org/abs/2003.00104", "code": "https://github.com/aub-mind/arabert", "dataset": {"name": "ArSenTD-Lev", "link": "http://www.oma-project.com/", "domain": "twitter"}, "measure": "Accuracy", "performance": 59.4, "multi_lingual": 51.0, "multi_difference": 8.4}, {"name": "SA", "source": "https://arxiv.org/abs/2003.00104", "code": "https://github.com/aub-mind/arabert", "dataset": {"name": "LABR", "link": "https://github.com/mohamedadaly/LABR", "domain": "book reviews"}, "measure": "Accuracy", "performance": 86.7, "multi_lingual": 83.0, "multi_difference": 3.7}, {"name": "NER", "source": "https://arxiv.org/abs/2003.00104", "code": "https://github.com/aub-mind/arabert", "dataset": {"name": "ANER-corp", "link": "https://github.com/EmnamoR/Arabic-named-entity-recognition", "domain": "news"}, "measure": "F1 (macro)", "performance": 81.9, "multi_lingual": 78.4, "multi_difference": 3.5}, {"name": "QA", "source": "https://arxiv.org/abs/2003.00104", "code": "https://github.com/aub-mind/arabert", "dataset": {"name": "ARCD", "link": "https://github.com/husseinmozannar/SOQAL", "domain": "wiki"}, "measure": "F1 (macro)", "performance": 62.7, "multi_lingual": 61.3, "multi_difference": 1.4}]}, {"name": "BERT-Large Portuguese", "language": "Portuguese", "tasks": [{"source": "https://github.com/neuralmind-ai/portuguese-bert", "code": "https://github.com/neuralmind-ai/portuguese-bert", "name": "NER", "dataset": {"name": "Harem", "link": "https://www.linguateca.pt/HAREM/", "domain": "web, politics, fiction, email, transcriptions, news, misc"}, "measure": "F1 (5 classes)", "performance": 83.3, "multi_lingual": 79.44, "multi_difference": 3.86}]}, {"name": "BERT-Base", "language": "English", "tasks": [{"source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "name": "NLI", "dataset": {"name": "MNLI (matched)", "link": "http://www.nyu.edu/projects/bowman/multinli/", "domain": "misc"}, "measure": "Accuracy (dev)", "performance": 84.6, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "Quora Question Pairs", "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs", "domain": "social"}, "measure": "F1 (dev)", "performance": 71.2, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "NLI", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "QNLI", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "Accuracy (dev)", "performance": 90.5, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SA", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "Stanford Sentiment Treebank", "link": "https://nlp.stanford.edu/sentiment/index.html", "domain": "movie reviews"}, "measure": "Accuracy (dev)", "performance": 93.5, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "LA", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "CoLA", "link": "https://nyu-mll.github.io/CoLA/", "domain": "misc"}, "measure": "Matthew's Correlation (dev)", "performance": 52.1, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "STS", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "STS-B", "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark", "domain": "misc"}, "measure": "Pearson-Spearman Correlation (dev)", "performance": 85.8, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "MRPC", "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm", "domain": "news"}, "measure": "F1 (dev)", "performance": 88.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "TER", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "RTE", "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment", "domain": "news, wiki"}, "measure": "Accuracy (dev)", "performance": 66.4, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "QA", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "SQuAD v1.1", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "F1 (dev)", "performance": 88.5, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "CI", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "SWAG", "link": "https://rowanzellers.com/swag/", "domain": "video captions"}, "measure": "Accuracy (dev)", "performance": 81.6, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "NLI", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/google-research/bert", "dataset": {"name": "WNLI", "link": "https://cs.nyu.edu/faculty/davise/papers/WinogradSchemas/WS.html", "domain": "fiction"}, "measure": "Accuracy", "performance": 45.1, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SA", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/google-research/bert", "dataset": {"name": "IMDb", "link": "https://ai.stanford.edu/~amaas/data/sentiment/", "domain": "movie reviews"}, "measure": "Accuracy", "performance": 93.46, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "BERT-Large", "language": "English", "tasks": [{"source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "name": "NLI", "dataset": {"name": "MNLI (matched)", "link": "http://www.nyu.edu/projects/bowman/multinli/", "domain": "misc"}, "measure": "Accuracy (dev)", "performance": 86.7, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "Quora Question Pairs", "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs", "domain": "social"}, "measure": "F1 (dev)", "performance": 72.1, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "NLI", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "QNLI", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "Accuracy (dev)", "performance": 92.7, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SA", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "Stanford Sentiment Treebank", "link": "https://nlp.stanford.edu/sentiment/index.html", "domain": "movie reviews"}, "measure": "Accuracy (dev)", "performance": 94.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "LA", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "CoLA", "link": "https://nyu-mll.github.io/CoLA/", "domain": "misc"}, "measure": "Matthew's Correlation (dev)", "performance": 60.5, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "STS", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "STS-B", "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark", "domain": "misc"}, "measure": "Pearson-Spearman Correlation (dev)", "performance": 86.5, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "MRPC", "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm", "domain": "news"}, "measure": "F1 (dev)", "performance": 89.3, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "TER", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "RTE", "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment", "domain": "news, wiki"}, "measure": "Accuracy (dev)", "performance": 70.1, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "QA", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "SQuAD v1.1", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "F1 (dev)", "performance": 90.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "QA", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "SQuAD v2.0", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "F1 (dev)", "performance": 81.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "CI", "source": "https://www.aclweb.org/anthology/N19-1423.pdf", "code": "https://github.com/google-research/bert", "dataset": {"name": "SWAG", "link": "https://rowanzellers.com/swag/", "domain": "video captions"}, "measure": "Accuracy (dev)", "performance": 86.6, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "RC", "source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/google-research/bert", "dataset": {"name": "RACE", "link": "https://www.cs.cmu.edu/~glai1/data/race/", "domain": "examinations"}, "measure": "Accuracy", "performance": 72.0, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "RoBERTa", "language": "English", "tasks": [{"source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md", "name": "NLI", "dataset": {"name": "MNLI (matched)", "link": "http://www.nyu.edu/projects/bowman/multinli/", "domain": "misc"}, "measure": "Accuracy (dev)", "performance": 90.2, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md", "dataset": {"name": "QQP", "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs", "domain": "social"}, "measure": "F1 (dev)", "performance": 92.2, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "NLI", "source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md", "dataset": {"name": "QNLI", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "Accuracy (dev)", "performance": 94.7, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SA", "source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md", "dataset": {"name": "Stanford Sentiment Treebank", "link": "https://nlp.stanford.edu/sentiment/index.html", "domain": "movie reviews"}, "measure": "Accuracy (dev)", "performance": 96.4, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "LA", "source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md", "dataset": {"name": "CoLA", "link": "https://nyu-mll.github.io/CoLA/", "domain": "misc"}, "measure": "Matthew's Correlation (dev)", "performance": 68.0, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "STS", "source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md", "dataset": {"name": "STS-B", "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark", "domain": "misc"}, "measure": "Pearson-Spearman Correlation (dev)", "performance": 92.4, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md", "dataset": {"name": "MRPC", "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm", "domain": "news"}, "measure": "F1 (dev)", "performance": 90.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "TER", "source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md", "dataset": {"name": "RTE", "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment", "domain": "news, wiki"}, "measure": "Accuracy (dev)", "performance": 86.6, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "QA", "source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md", "dataset": {"name": "SQuAD v1.1", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "F1 (dev)", "performance": 94.6, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "QA", "source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md", "dataset": {"name": "SQuAD v2.0", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "F1 (dev)", "performance": 89.4, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "RC", "source": "https://arxiv.org/abs/1907.11692", "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md", "dataset": {"name": "RACE", "link": "https://www.cs.cmu.edu/~glai1/data/race/", "domain": "examinations"}, "measure": "Accuracy", "performance": 83.2, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "ALBERT (1M)", "language": "English", "tasks": [{"source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "name": "NLI", "dataset": {"name": "MNLI (matched)", "link": "http://www.nyu.edu/projects/bowman/multinli/", "domain": "misc"}, "measure": "Accuracy (dev)", "performance": 90.4, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "QQP", "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs", "domain": "social"}, "measure": "F1 (dev)", "performance": 92.0, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "NLI", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "QNLI", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "Accuracy (dev)", "performance": 95.2, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SA", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "Stanford Sentiment Treebank", "link": "https://nlp.stanford.edu/sentiment/index.html", "domain": "movie reviews"}, "measure": "Accuracy (dev)", "performance": 96.8, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "LA", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "CoLA", "link": "https://nyu-mll.github.io/CoLA/", "domain": "misc"}, "measure": "Matthew's Correlation (dev)", "performance": 68.7, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "STS", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "STS-B", "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark", "domain": "misc"}, "measure": "Pearson-Spearman Correlation (dev)", "performance": 92.7, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "MRPC", "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm", "domain": "news"}, "measure": "F1 (dev)", "performance": 90.2, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "TER", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "RTE", "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment", "domain": "news, wiki"}, "measure": "Accuracy (dev)", "performance": 88.1, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "QA", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "SQuAD v1.1", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "F1 (dev)", "performance": 94.8, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "QA", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "SQuAD v2.0", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "F1 (dev)", "performance": 89.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "RC", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "RACE", "link": "https://www.cs.cmu.edu/~glai1/data/race/", "domain": "examinations"}, "measure": "Accuracy", "performance": 86.0, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "ALBERT (1.5M)", "language": "English", "tasks": [{"source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "name": "NLI", "dataset": {"name": "MNLI (matched)", "link": "http://www.nyu.edu/projects/bowman/multinli/", "domain": "misc"}, "measure": "Accuracy (dev)", "performance": 90.8, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "QQP", "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs", "domain": "social"}, "measure": "F1 (dev)", "performance": 92.2, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "NLI", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "QNLI", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "Accuracy (dev)", "performance": 95.3, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SA", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "Stanford Sentiment Treebank", "link": "https://nlp.stanford.edu/sentiment/index.html", "domain": "movie reviews"}, "measure": "Accuracy (dev)", "performance": 96.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "LA", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "CoLA", "link": "https://nyu-mll.github.io/CoLA/", "domain": "misc"}, "measure": "Matthew's Correlation (dev)", "performance": 71.4, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "STS", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "STS-B", "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark", "domain": "misc"}, "measure": "Pearson-Spearman Correlation (dev)", "performance": 93.0, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "MRPC", "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm", "domain": "news"}, "measure": "F1 (dev)", "performance": 90.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "TER", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "RTE", "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment", "domain": "news, wiki"}, "measure": "Accuracy (dev)", "performance": 89.2, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "QA", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "SQuAD v1.1", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "F1 (dev)", "performance": 94.8, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "QA", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "SQuAD v2.0", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "F1 (dev)", "performance": 90.2, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "RC", "source": "https://arxiv.org/abs/1909.11942", "code": "https://github.com/google-research/ALBERT", "dataset": {"name": "RACE", "link": "https://www.cs.cmu.edu/~glai1/data/race/", "domain": "examinations"}, "measure": "Accuracy", "performance": 86.5, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "DistilBERT", "language": "English", "tasks": [{"source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation", "name": "NLI", "dataset": {"name": "MNLI (matched)", "link": "http://www.nyu.edu/projects/bowman/multinli/", "domain": "misc"}, "measure": "Accuracy (dev)", "performance": 79.0, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation", "dataset": {"name": "QQP", "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs", "domain": "social"}, "measure": "F1 (dev)", "performance": 84.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "NLI", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation", "dataset": {"name": "QNLI", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "Accuracy (dev)", "performance": 85.3, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SA", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation", "dataset": {"name": "Stanford Sentiment Treebank", "link": "https://nlp.stanford.edu/sentiment/index.html", "domain": "movie reviews"}, "measure": "Accuracy (dev)", "performance": 90.7, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "LA", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation", "dataset": {"name": "CoLA", "link": "https://nyu-mll.github.io/CoLA/", "domain": "misc"}, "measure": "Matthew's Correlation (dev)", "performance": 43.6, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "STS", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation", "dataset": {"name": "STS-B", "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark", "domain": "misc"}, "measure": "Pearson-Spearman Correlation (dev)", "performance": 81.2, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "PI", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation", "dataset": {"name": "MRPC", "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm", "domain": "news"}, "measure": "F1 (dev)", "performance": 87.5, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "TER", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation", "dataset": {"name": "RTE", "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment", "domain": "news, wiki"}, "measure": "Accuracy (dev)", "performance": 59.9, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "QA", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation", "dataset": {"name": "SQuAD v1.1", "link": "https://rajpurkar.github.io/SQuAD-explorer/", "domain": "wiki"}, "measure": "F1 (dev)", "performance": 78.7, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "NLI", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation", "dataset": {"name": "WNLI", "link": "https://cs.nyu.edu/faculty/davise/papers/WinogradSchemas/WS.html", "domain": "fiction"}, "measure": "Accuracy", "performance": 56.3, "multi_lingual": "nan", "multi_difference": "nan"}, {"name": "SA", "source": "https://arxiv.org/abs/1910.01108", "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation", "dataset": {"name": "IMDb", "link": "https://ai.stanford.edu/~amaas/data/sentiment/", "domain": "movie reviews"}, "measure": "Accuracy", "performance": 92.82, "multi_lingual": "nan", "multi_difference": "nan"}]}, {"name": "Fine-Tuned mBERT", "language": "Yor\u00f9b\u00e1", "tasks": [{"source": "https://arxiv.org/abs/1912.02481", "code": "https://github.com/ajesujoba/YorubaTwi-Embedding", "name": "NER", "dataset": {"name": "Global Voices Yor\u00f9b\u00e1", "link": "https://yo.globalvoices.org/", "domain": "news"}, "measure": "F1", "performance": 52.5, "multi_lingual": 0.0, "multi_difference": 52.5}]}, {"name": "BERT-Tagalog", "language": "Philipino", "tasks": [{"source": "https://arxiv.org/pdf/1907.00409.pdf", "code": "https://github.com/jcblaisecruz02/Tagalog-BERT", "name": "SA", "dataset": {"name": "-", "link": "-", "domain": "electronic products reviews"}, "measure": "Accuracy", "performance": 88.17, "multi_lingual": "nan", "multi_difference": "nan"}]}]
+[
+    {
+        "name": "BERTje",
+        "language": "Dutch",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/1912.09582",
+                "code": "https://github.com/wietsedv/bertje",
+                "name": "NER",
+                "dataset": {
+                    "name": "CoNLL-2002",
+                    "link": "https://www.clips.uantwerpen.be/conll2002/ner/",
+                    "domain": "news"
+                },
+                "measure": "F1 (test)",
+                "performance": 88.3,
+                "multi_lingual": 80.7,
+                "multi_difference": 7.6
+            },
+            {
+                "name": "NER",
+                "source": "https://arxiv.org/abs/1912.09582",
+                "code": "https://github.com/wietsedv/bertje",
+                "dataset": {
+                    "name": "SoNaR-1",
+                    "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus",
+                    "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"
+                },
+                "measure": "F1 (test)",
+                "performance": 82.1,
+                "multi_lingual": 79.7,
+                "multi_difference": 2.4
+            },
+            {
+                "name": "POS",
+                "source": "https://arxiv.org/abs/1912.09582",
+                "code": "https://github.com/wietsedv/bertje",
+                "dataset": {
+                    "name": "UD-LassySmall",
+                    "link": "https://universaldependencies.org/treebanks/nl_lassysmall/index.html",
+                    "domain": "wiki"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 96.3,
+                "multi_lingual": 92.5,
+                "multi_difference": 3.8
+            },
+            {
+                "name": "POS (C)",
+                "source": "https://arxiv.org/abs/1912.09582",
+                "code": "https://github.com/wietsedv/bertje",
+                "dataset": {
+                    "name": "SoNaR-1",
+                    "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus",
+                    "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 98.5,
+                "multi_lingual": 98.3,
+                "multi_difference": 0.2
+            },
+            {
+                "name": "POS (FG)",
+                "source": "https://arxiv.org/abs/1912.09582",
+                "code": "https://github.com/wietsedv/bertje",
+                "dataset": {
+                    "name": "SoNaR-1",
+                    "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus",
+                    "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 96.8,
+                "multi_lingual": 96.2,
+                "multi_difference": 0.6
+            },
+            {
+                "name": "SRL-PA",
+                "source": "https://arxiv.org/abs/1912.09582",
+                "code": "https://github.com/wietsedv/bertje",
+                "dataset": {
+                    "name": "SoNaR-1",
+                    "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus",
+                    "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"
+                },
+                "measure": "F1 (test)",
+                "performance": 85.3,
+                "multi_lingual": 80.4,
+                "multi_difference": 4.9
+            },
+            {
+                "name": "SRL-M",
+                "source": "https://arxiv.org/abs/1912.09582",
+                "code": "https://github.com/wietsedv/bertje",
+                "dataset": {
+                    "name": "SoNaR-1",
+                    "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus",
+                    "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"
+                },
+                "measure": "F1 (test)",
+                "performance": 67.2,
+                "multi_lingual": 62.4,
+                "multi_difference": 4.8
+            },
+            {
+                "name": "SRT",
+                "source": "https://arxiv.org/abs/1912.09582",
+                "code": "https://github.com/wietsedv/bertje",
+                "dataset": {
+                    "name": "SoNaR-1",
+                    "link": "https://ivdnt.org/downloads/taalmaterialen/tstc-sonar-corpus",
+                    "domain": "news, social, legal, manual, wiki, web, press, proceedings, misc"
+                },
+                "measure": "macro F1 (test)",
+                "performance": 64.3,
+                "multi_lingual": 57.3,
+                "multi_difference": 7.0
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1912.09582",
+                "code": "https://github.com/wietsedv/bertje",
+                "dataset": {
+                    "name": "110k Dutch Book Reviews Dataset",
+                    "link": "https://benjaminvdb.github.io/110kDBRD/",
+                    "domain": "book Reviews"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 93.0,
+                "multi_lingual": 89.1,
+                "multi_difference": 3.9
+            },
+            {
+                "name": "DDD",
+                "source": "https://arxiv.org/abs/2001.06286",
+                "code": "https://github.com/iPieter/RobBERT",
+                "dataset": {
+                    "name": "Europarl",
+                    "link": "https://www.statmt.org/europarl/",
+                    "domain": "proceedings"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 98.27,
+                "multi_lingual": 98.28,
+                "multi_difference": -0.01
+            }
+        ]
+    },
+    {
+        "name": "RobBERT",
+        "language": "Dutch",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/2001.06286",
+                "code": "https://github.com/iPieter/RobBERT",
+                "name": "SA",
+                "dataset": {
+                    "name": "110k Dutch Book Reviews Dataset",
+                    "link": "https://benjaminvdb.github.io/110kDBRD/",
+                    "domain": "book Reviews"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 94.42,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "DDD",
+                "source": "https://arxiv.org/abs/2001.06286",
+                "code": "https://github.com/iPieter/RobBERT",
+                "dataset": {
+                    "name": "Europarl",
+                    "link": "https://www.statmt.org/europarl/",
+                    "domain": "proceedings"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 98.41,
+                "multi_lingual": 98.28,
+                "multi_difference": 0.13
+            }
+        ]
+    },
+    {
+        "name": "CamemBERT",
+        "language": "French",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "name": "POS",
+                "dataset": {
+                    "name": "GSD",
+                    "link": "https://github.com/ryanmcd/uni-dep-tb",
+                    "domain": "blogs, news, reviews, wiki"
+                },
+                "measure": "UPOS",
+                "performance": 98.19,
+                "multi_lingual": 97.48,
+                "multi_difference": 0.71
+            },
+            {
+                "name": "DP-UAS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "GSD",
+                    "link": "https://github.com/ryanmcd/uni-dep-tb",
+                    "domain": "blogs, news, reviews, wiki"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 94.82,
+                "multi_lingual": 92.72,
+                "multi_difference": 2.1
+            },
+            {
+                "name": "DP-LAS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "GSD",
+                    "link": "https://github.com/ryanmcd/uni-dep-tb",
+                    "domain": "blogs, news, reviews, wiki"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 92.47,
+                "multi_lingual": 89.73,
+                "multi_difference": 2.74
+            },
+            {
+                "name": "POS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "Sequoia",
+                    "link": "https://deep-sequoia.inria.fr/",
+                    "domain": "politics, news, wiki, agency"
+                },
+                "measure": "UPOS",
+                "performance": 99.21,
+                "multi_lingual": 98.41,
+                "multi_difference": 0.8
+            },
+            {
+                "name": "DP-UAS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "Sequoia",
+                    "link": "https://deep-sequoia.inria.fr/",
+                    "domain": "politics, news, wiki, agency"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 95.56,
+                "multi_lingual": 93.24,
+                "multi_difference": 2.32
+            },
+            {
+                "name": "DP-LAS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "Sequoia",
+                    "link": "https://deep-sequoia.inria.fr/",
+                    "domain": "politics, news, wiki, agency"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 94.39,
+                "multi_lingual": 91.24,
+                "multi_difference": 3.15
+            },
+            {
+                "name": "POS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "Spoken",
+                    "link": "https://www.projet-rhapsodie.fr/",
+                    "domain": "transcription"
+                },
+                "measure": "UPOS",
+                "performance": 96.68,
+                "multi_lingual": 96.02,
+                "multi_difference": 0.66
+            },
+            {
+                "name": "DP-UAS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "Spoken",
+                    "link": "https://www.projet-rhapsodie.fr/",
+                    "domain": "transcription"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 86.05,
+                "multi_lingual": 84.65,
+                "multi_difference": 1.4
+            },
+            {
+                "name": "DP-LAS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "Spoken",
+                    "link": "https://www.projet-rhapsodie.fr/",
+                    "domain": "transcription"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 80.07,
+                "multi_lingual": 78.63,
+                "multi_difference": 1.44
+            },
+            {
+                "name": "POS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "ParTUT",
+                    "link": "http://www.di.unito.it/~tutreeb/treebanks.html",
+                    "domain": "legal, license, misc"
+                },
+                "measure": "UPOS",
+                "performance": 97.63,
+                "multi_lingual": 97.35,
+                "multi_difference": 0.28
+            },
+            {
+                "name": "DP-UAS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "ParTUT",
+                    "link": "http://www.di.unito.it/~tutreeb/treebanks.html",
+                    "domain": "legal, license, misc"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 95.21,
+                "multi_lingual": 94.18,
+                "multi_difference": 1.03
+            },
+            {
+                "name": "DP-LAS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "ParTUT",
+                    "link": "http://www.di.unito.it/~tutreeb/treebanks.html",
+                    "domain": "legal, license, misc"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 92.2,
+                "multi_lingual": 91.37,
+                "multi_difference": 0.83
+            },
+            {
+                "name": "POS",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "French Treebank",
+                    "link": "http://ftb.linguist.univ-paris-diderot.fr/telecharger.php?langue=en",
+                    "domain": "news"
+                },
+                "measure": "F1",
+                "performance": 87.93,
+                "multi_lingual": 82.75,
+                "multi_difference": 5.18
+            },
+            {
+                "name": "NLI",
+                "source": "https://arxiv.org/abs/1911.03894",
+                "code": "https://camembert-model.fr/",
+                "dataset": {
+                    "name": "XNLI (French)",
+                    "link": "https://github.com/facebookresearch/XNLI",
+                    "domain": "transcription, politics, news, literature, misc"
+                },
+                "measure": "Accuracy",
+                "performance": 81.2,
+                "multi_lingual": 76.9,
+                "multi_difference": 4.3
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "CLS (French)",
+                    "link": "https://webis.de/data/webis-cls-10.html",
+                    "domain": "book reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 93.4,
+                "multi_lingual": 86.15,
+                "multi_difference": 7.25
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "CLS (French)",
+                    "link": "https://webis.de/data/webis-cls-10.html",
+                    "domain": "dvd reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 92.7,
+                "multi_lingual": 86.9,
+                "multi_difference": 5.8
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "CLS (French)",
+                    "link": "https://webis.de/data/webis-cls-10.html",
+                    "domain": "music reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 94.15,
+                "multi_lingual": 86.65,
+                "multi_difference": 7.5
+            },
+            {
+                "name": "PI",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "PAWS-X (French)",
+                    "link": "https://github.com/google-research-datasets/paws",
+                    "domain": "wiki"
+                },
+                "measure": "Accuracy",
+                "performance": 89.8,
+                "multi_lingual": 89.3,
+                "multi_difference": 0.5
+            },
+            {
+                "name": "POS",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "French Treebank",
+                    "link": "http://ftb.linguist.univ-paris-diderot.fr/telecharger.php?langue=en",
+                    "domain": "news"
+                },
+                "measure": "F1 (test)",
+                "performance": 88.39,
+                "multi_lingual": 87.52,
+                "multi_difference": 0.87
+            },
+            {
+                "name": "VSD",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "FrenchSemeval",
+                    "link": "http://www.llf.cnrs.fr/dataset/fse/",
+                    "domain": "wiki"
+                },
+                "measure": "F1",
+                "performance": 51.9,
+                "multi_lingual": 44.93,
+                "multi_difference": 6.97
+            },
+            {
+                "name": "NSD",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "Semeval 2013 Task 12 (French)",
+                    "link": "https://www.cs.york.ac.uk/semeval-2013/",
+                    "domain": "news"
+                },
+                "measure": "F1",
+                "performance": 51.52,
+                "multi_lingual": 53.48,
+                "multi_difference": -1.96
+            }
+        ]
+    },
+    {
+        "name": "FlauBERT",
+        "language": "French",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "name": "SA",
+                "dataset": {
+                    "name": "CLS (French)",
+                    "link": "https://webis.de/data/webis-cls-10.html",
+                    "domain": "book reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 93.4,
+                "multi_lingual": 86.15,
+                "multi_difference": 7.25
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "CLS (French)",
+                    "link": "https://webis.de/data/webis-cls-10.html",
+                    "domain": "dvd reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 92.5,
+                "multi_lingual": 86.9,
+                "multi_difference": 5.6
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "CLS (French)",
+                    "link": "https://webis.de/data/webis-cls-10.html",
+                    "domain": "music reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 94.3,
+                "multi_lingual": 86.65,
+                "multi_difference": 7.65
+            },
+            {
+                "name": "PI",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "PAWS-X (French)",
+                    "link": "https://github.com/google-research-datasets/paws",
+                    "domain": "wiki"
+                },
+                "measure": "Accuracy",
+                "performance": 89.9,
+                "multi_lingual": 89.3,
+                "multi_difference": 0.6
+            },
+            {
+                "name": "NLI",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "XNLI",
+                    "link": "https://github.com/facebookresearch/XNLI",
+                    "domain": "transcription, politics, news, literature, misc"
+                },
+                "measure": "Accuracy",
+                "performance": 81.3,
+                "multi_lingual": 76.9,
+                "multi_difference": 4.4
+            },
+            {
+                "name": "NER",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "French Treebank",
+                    "link": "http://ftb.linguist.univ-paris-diderot.fr/telecharger.php?langue=en",
+                    "domain": "news"
+                },
+                "measure": "F1 (test)",
+                "performance": 89.05,
+                "multi_lingual": 87.52,
+                "multi_difference": 1.53
+            },
+            {
+                "name": "VSD",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "FrenchSemeval",
+                    "link": "http://www.llf.cnrs.fr/dataset/fse/",
+                    "domain": "wiki"
+                },
+                "measure": "F1",
+                "performance": 47.4,
+                "multi_lingual": 44.93,
+                "multi_difference": 2.47
+            },
+            {
+                "name": "NSD",
+                "source": "https://arxiv.org/abs/1912.05372",
+                "code": "https://github.com/getalp/Flaubert",
+                "dataset": {
+                    "name": "Semeval 2013 Task 12 (French)",
+                    "link": "https://www.cs.york.ac.uk/semeval-2013/",
+                    "domain": "news"
+                },
+                "measure": "F1",
+                "performance": 50.78,
+                "multi_lingual": 53.48,
+                "multi_difference": -2.7
+            }
+        ]
+    },
+    {
+        "name": "FinBERT",
+        "language": "Finnish",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/1912.07076",
+                "code": "http://turkunlp.org/FinBERT/",
+                "name": "POS",
+                "dataset": {
+                    "name": "Turku Dependency Treebank",
+                    "link": "https://turkunlp.org/finnish_nlp.html#treebank",
+                    "domain": "wiki, news, blog, speech, legislative, fiction"
+                },
+                "measure": "UPOS",
+                "performance": 98.23,
+                "multi_lingual": 96.97,
+                "multi_difference": 1.26
+            },
+            {
+                "name": "POS",
+                "source": "https://arxiv.org/abs/1912.07076",
+                "code": "http://turkunlp.org/FinBERT/",
+                "dataset": {
+                    "name": "FinnTreeBank",
+                    "link": "http://www.ling.helsinki.fi/kieliteknologia/tutkimus/treebank/index-print.shtml",
+                    "domain": "grammar, news, literature, politics, legislative, misc"
+                },
+                "measure": "UPOS",
+                "performance": 98.39,
+                "multi_lingual": 95.87,
+                "multi_difference": 2.52
+            },
+            {
+                "name": "POS",
+                "source": "https://arxiv.org/abs/1912.07076",
+                "code": "http://turkunlp.org/FinBERT/",
+                "dataset": {
+                    "name": "Parallel UD treebank",
+                    "link": "http://universaldependencies.org/conll17/data.html",
+                    "domain": "wiki, news"
+                },
+                "measure": "UPOS",
+                "performance": 98.08,
+                "multi_lingual": 97.58,
+                "multi_difference": 0.5
+            },
+            {
+                "name": "NER",
+                "source": "https://arxiv.org/abs/1912.07076",
+                "code": "http://turkunlp.org/FinBERT/",
+                "dataset": {
+                    "name": "FiNER",
+                    "link": "http://metashare.csc.fi/repository/browse/finnish-news-corpus-for-named-entity-recognition/a10cea3c69ef11e9b99d005056be118e9c015616f4294cd9af85b019714ffb3c/",
+                    "domain": "wiki, news"
+                },
+                "measure": "F1",
+                "performance": 92.4,
+                "multi_lingual": 90.29,
+                "multi_difference": 2.11
+            },
+            {
+                "name": "DP",
+                "source": "https://arxiv.org/abs/1912.07076",
+                "code": "http://turkunlp.org/FinBERT/",
+                "dataset": {
+                    "name": "Turku Dependency Treebank",
+                    "link": "https://turkunlp.org/finnish_nlp.html#treebank",
+                    "domain": "wiki, news, blog, speech, legislative, fiction"
+                },
+                "measure": "LAS (predicted segmentation)",
+                "performance": 91.93,
+                "multi_lingual": 86.32,
+                "multi_difference": 5.61
+            },
+            {
+                "name": "DP",
+                "source": "https://arxiv.org/abs/1912.07076",
+                "code": "http://turkunlp.org/FinBERT/",
+                "dataset": {
+                    "name": "FinnTreeBank",
+                    "link": "http://www.ling.helsinki.fi/kieliteknologia/tutkimus/treebank/index-print.shtml",
+                    "domain": "grammar, news, literature, politics, legislative, misc"
+                },
+                "measure": "LAS (predicted segmentation)",
+                "performance": 92.16,
+                "multi_lingual": 85.52,
+                "multi_difference": 6.64
+            },
+            {
+                "name": "DP",
+                "source": "https://arxiv.org/abs/1912.07076",
+                "code": "http://turkunlp.org/FinBERT/",
+                "dataset": {
+                    "name": "Parallel UD treebank",
+                    "link": "http://universaldependencies.org/conll17/data.html",
+                    "domain": "wiki, news"
+                },
+                "measure": "LAS (predicted segmentation)",
+                "performance": 92.54,
+                "multi_lingual": 89.18,
+                "multi_difference": 3.36
+            },
+            {
+                "name": "TC",
+                "source": "https://arxiv.org/abs/1912.07076",
+                "code": "http://turkunlp.org/FinBERT/",
+                "dataset": {
+                    "name": "Yle news",
+                    "link": "https://github.com/spyysalo/yle-corpus",
+                    "domain": "news"
+                },
+                "measure": "Accuracy (test size 10K)",
+                "performance": 90.57,
+                "multi_lingual": 88.44,
+                "multi_difference": 2.13
+            },
+            {
+                "name": "TC",
+                "source": "https://arxiv.org/abs/1912.07076",
+                "code": "http://turkunlp.org/FinBERT/",
+                "dataset": {
+                    "name": "Ylilauta online discussion",
+                    "link": "https://github.com/spyysalo/ylilauta-corpus",
+                    "domain": "social"
+                },
+                "measure": "Accuracy (test size 10K)",
+                "performance": 79.18,
+                "multi_lingual": 67.92,
+                "multi_difference": 11.26
+            }
+        ]
+    },
+    {
+        "name": "Italian BERT (XXL)",
+        "language": "Italian",
+        "tasks": [
+            {
+                "source": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md",
+                "code": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md",
+                "name": "NER",
+                "dataset": {
+                    "name": "WikiNER",
+                    "link": "https://github.com/dice-group/FOX/tree/master/input/Wikiner",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (test)",
+                "performance": 93.61,
+                "multi_lingual": 93.53,
+                "multi_difference": 0.08
+            },
+            {
+                "name": "NER",
+                "source": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md",
+                "code": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md",
+                "dataset": {
+                    "name": "I-CAB 2009",
+                    "link": "http://ontotext.fbk.eu/icab.html",
+                    "domain": "news"
+                },
+                "measure": "F1",
+                "performance": 88.13,
+                "multi_lingual": 85.18,
+                "multi_difference": 2.95
+            },
+            {
+                "name": "POS",
+                "source": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md",
+                "code": "https://github.com/huggingface/transformers/blob/master/model_cards/dbmdz/bert-base-italian-cased/README.md",
+                "dataset": {
+                    "name": "PoSTWITA",
+                    "link": "http://www.evalita.it/2016/tasks/postwita",
+                    "domain": "twitter"
+                },
+                "measure": "Accuracy",
+                "performance": 93.75,
+                "multi_lingual": 91.54,
+                "multi_difference": 2.21
+            }
+        ]
+    },
+    {
+        "name": "ALBERTO",
+        "language": "Italian",
+        "tasks": [
+            {
+                "source": "http://ceur-ws.org/Vol-2481/paper57.pdf",
+                "code": "https://github.com/marcopoli/AlBERTo-it",
+                "name": "SA",
+                "dataset": {
+                    "name": "SENTIPOLC 2016",
+                    "link": "http://www.di.unito.it/~tutreeb/sentipolc-evalita16/data.html",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 72.23,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SC",
+                "source": "http://ceur-ws.org/Vol-2481/paper57.pdf",
+                "code": "https://github.com/marcopoli/AlBERTo-it",
+                "dataset": {
+                    "name": "SENTIPOLC 2016",
+                    "link": "http://www.di.unito.it/~tutreeb/sentipolc-evalita16/data.html",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 79.06,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "ID",
+                "source": "http://ceur-ws.org/Vol-2481/paper57.pdf",
+                "code": "https://github.com/marcopoli/AlBERTo-it",
+                "dataset": {
+                    "name": "SENTIPOLC 2016",
+                    "link": "http://www.di.unito.it/~tutreeb/sentipolc-evalita16/data.html",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 60.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "Gilberto",
+        "language": "Italian",
+        "tasks": [
+            {
+                "source": "https://github.com/idb-ita/GilBERTo",
+                "code": "https://github.com/idb-ita/GilBERTo",
+                "name": "POS",
+                "dataset": {
+                    "name": "ParTUT",
+                    "link": "http://www.di.unito.it/~tutreeb/treebanks.html",
+                    "domain": "legal, license, misc"
+                },
+                "measure": "UPOS",
+                "performance": 98.8,
+                "multi_lingual": 98.0,
+                "multi_difference": 0.8
+            },
+            {
+                "name": "POS",
+                "source": "https://github.com/idb-ita/GilBERTo",
+                "code": "https://github.com/idb-ita/GilBERTo",
+                "dataset": {
+                    "name": "ISDT",
+                    "link": "https://github.com/UniversalDependencies/UD_Italian-ISDT",
+                    "domain": "legal, news, wiki, misc"
+                },
+                "measure": "UPOS",
+                "performance": 98.6,
+                "multi_lingual": 98.5,
+                "multi_difference": 0.1
+            },
+            {
+                "name": "NER",
+                "source": "https://github.com/idb-ita/GilBERTo",
+                "code": "https://github.com/idb-ita/GilBERTo",
+                "dataset": {
+                    "name": "WikiNER",
+                    "link": "https://github.com/dice-group/FOX/tree/master/input/Wikiner",
+                    "domain": "wiki"
+                },
+                "measure": "F1",
+                "performance": 92.7,
+                "multi_lingual": 92.2,
+                "multi_difference": 0.5
+            }
+        ]
+    },
+    {
+        "name": "Umberto",
+        "language": "Italian",
+        "tasks": [
+            {
+                "source": "https://github.com/musixmatchresearch/umberto",
+                "code": "https://github.com/musixmatchresearch/umberto",
+                "name": "POS",
+                "dataset": {
+                    "name": "ParTUT",
+                    "link": "http://www.di.unito.it/~tutreeb/treebanks.html",
+                    "domain": "legal, license, misc"
+                },
+                "measure": "Accuracy",
+                "performance": 98.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "POS",
+                "source": "https://github.com/musixmatchresearch/umberto",
+                "code": "https://github.com/musixmatchresearch/umberto",
+                "dataset": {
+                    "name": "ISDT",
+                    "link": "https://github.com/UniversalDependencies/UD_Italian-ISDT",
+                    "domain": "legal, news, wiki, misc"
+                },
+                "measure": "Accuracy",
+                "performance": 98.98,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "NER",
+                "source": "https://github.com/musixmatchresearch/umberto",
+                "code": "https://github.com/musixmatchresearch/umberto",
+                "dataset": {
+                    "name": "WikiNER",
+                    "link": "https://github.com/dice-group/FOX/tree/master/input/Wikiner",
+                    "domain": "wiki"
+                },
+                "measure": "F1",
+                "performance": 92.53,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "NER",
+                "source": "https://github.com/musixmatchresearch/umberto",
+                "code": "https://github.com/musixmatchresearch/umberto",
+                "dataset": {
+                    "name": "I-CAB 2007",
+                    "link": "http://ontotext.fbk.eu/icab.html",
+                    "domain": "news"
+                },
+                "measure": "F1",
+                "performance": 92.53,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "deepset-GermanBERT",
+        "language": "German",
+        "tasks": [
+            {
+                "source": "https://deepset.ai/german-bert",
+                "code": "https://deepset.ai/german-bert",
+                "name": "IOL",
+                "dataset": {
+                    "name": "germEval18Fine",
+                    "link": "https://github.com/uds-lsv/GermEval-2018-Data",
+                    "domain": "twitter"
+                },
+                "measure": "F1",
+                "performance": 74.7,
+                "multi_lingual": 71.0,
+                "multi_difference": 3.7
+            },
+            {
+                "name": "IOL",
+                "source": "https://deepset.ai/german-bert",
+                "code": "https://deepset.ai/german-bert",
+                "dataset": {
+                    "name": "germEval18coarse",
+                    "link": "https://github.com/uds-lsv/GermEval-2018-Data",
+                    "domain": "twitter"
+                },
+                "measure": "F1",
+                "performance": 48.8,
+                "multi_lingual": 44.1,
+                "multi_difference": 4.7
+            },
+            {
+                "name": "NER",
+                "source": "https://deepset.ai/german-bert",
+                "code": "https://deepset.ai/german-bert",
+                "dataset": {
+                    "name": "germEval14",
+                    "link": "https://sites.google.com/site/germeval2014ner/data",
+                    "domain": "wiki, news"
+                },
+                "measure": "F1",
+                "performance": 84.0,
+                "multi_lingual": 83.4,
+                "multi_difference": 0.6
+            },
+            {
+                "name": "NER",
+                "source": "https://deepset.ai/german-bert",
+                "code": "https://deepset.ai/german-bert",
+                "dataset": {
+                    "name": "CoNLL-2003",
+                    "link": "https://github.com/MaviccPRP/ger_ner_evals/tree/master/corpora/conll2003",
+                    "domain": "news"
+                },
+                "measure": "F1",
+                "performance": 80.4,
+                "multi_lingual": 79.2,
+                "multi_difference": 1.2
+            },
+            {
+                "name": "TC",
+                "source": "https://deepset.ai/german-bert",
+                "code": "https://deepset.ai/german-bert",
+                "dataset": {
+                    "name": "10kGNAD",
+                    "link": "https://github.com/tblock/10kGNAD",
+                    "domain": "news"
+                },
+                "measure": "Accuracy",
+                "performance": 90.5,
+                "multi_lingual": 88.8,
+                "multi_difference": 1.7
+            },
+            {
+                "name": "NER",
+                "source": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "code": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "dataset": {
+                    "name": "CoNLL-2003",
+                    "link": "https://github.com/MaviccPRP/ger_ner_evals/tree/master/corpora/conll2003",
+                    "domain": "news"
+                },
+                "measure": "F1 (test)",
+                "performance": 83.7,
+                "multi_lingual": 82.55,
+                "multi_difference": 1.15
+            },
+            {
+                "name": "NER",
+                "source": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "code": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "dataset": {
+                    "name": "germEval14",
+                    "link": "https://sites.google.com/site/germeval2014ner/data",
+                    "domain": "wiki, news"
+                },
+                "measure": "F1 (test)",
+                "performance": 86.61,
+                "multi_lingual": 86.26,
+                "multi_difference": 0.35
+            },
+            {
+                "name": "POS",
+                "source": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "code": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "dataset": {
+                    "name": "Parallel UD treebank",
+                    "link": "https://universaldependencies.org/treebanks/de_hdt/index.html",
+                    "domain": "wiki, news"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 98.56,
+                "multi_lingual": 98.58,
+                "multi_difference": -0.02
+            }
+        ]
+    },
+    {
+        "name": "German BERT",
+        "language": "German",
+        "tasks": [
+            {
+                "source": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "code": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "name": "POS",
+                "dataset": {
+                    "name": "Parallel UD treebank",
+                    "link": "https://universaldependencies.org/treebanks/de_hdt/index.html",
+                    "domain": "wiki, news"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 98.57,
+                "multi_lingual": 98.58,
+                "multi_difference": -0.01
+            },
+            {
+                "name": "NER",
+                "source": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "code": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "dataset": {
+                    "name": "germEval14",
+                    "link": "https://sites.google.com/site/germeval2014ner/data",
+                    "domain": "wiki, news"
+                },
+                "measure": "F1 (test)",
+                "performance": 86.89,
+                "multi_lingual": 86.26,
+                "multi_difference": 0.63
+            },
+            {
+                "name": "NER",
+                "source": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "code": "https://github.com/dbmdz/berts/blob/master/README.md",
+                "dataset": {
+                    "name": "CoNLL-2003",
+                    "link": "https://github.com/MaviccPRP/ger_ner_evals/tree/master/corpora/conll2003",
+                    "domain": "news"
+                },
+                "measure": "F1 (test)",
+                "performance": 84.52,
+                "multi_lingual": 82.55,
+                "multi_difference": 1.97
+            }
+        ]
+    },
+    {
+        "name": "German Europeana BERT",
+        "language": "German",
+        "tasks": [
+            {
+                "source": "https://github.com/dbmdz/berts/blob/master/README.md#german-europeana-bert",
+                "code": "https://github.com/dbmdz/berts/blob/master/README.md#german-europeana-bert",
+                "name": "NER",
+                "dataset": {
+                    "name": "LFT",
+                    "link": "https://github.com/KBNLresearch/europeananp-ner/",
+                    "domain": "news"
+                },
+                "measure": "F1",
+                "performance": 80.55,
+                "multi_lingual": 77.26,
+                "multi_difference": 3.29
+            },
+            {
+                "name": "NER",
+                "source": "https://github.com/dbmdz/berts/blob/master/README.md#german-europeana-bert",
+                "code": "https://github.com/dbmdz/berts/blob/master/README.md#german-europeana-bert",
+                "dataset": {
+                    "name": "ONB ",
+                    "link": "https://github.com/KBNLresearch/europeananp-ner/",
+                    "domain": "news"
+                },
+                "measure": "F1",
+                "performance": 85.5,
+                "multi_lingual": 83.44,
+                "multi_difference": 2.06
+            }
+        ]
+    },
+    {
+        "name": "BETO",
+        "language": "Spanish",
+        "tasks": [
+            {
+                "source": "https://github.com/dccuchile/beto",
+                "code": "https://github.com/dccuchile/beto",
+                "name": "POS",
+                "dataset": {
+                    "name": "Turku Dependency Treebank",
+                    "link": "https://lindat.mff.cuni.cz/repository/xmlui/handle/11234/1-1827",
+                    "domain": "wiki, news, blog, speech, legislative, fiction"
+                },
+                "measure": "UPOS",
+                "performance": 98.97,
+                "multi_lingual": 97.1,
+                "multi_difference": 1.87
+            },
+            {
+                "name": "NER",
+                "source": "https://github.com/dccuchile/beto",
+                "code": "https://github.com/dccuchile/beto",
+                "dataset": {
+                    "name": "CoNLL 2000, 2002, 2007",
+                    "link": "https://www.kaggle.com/nltkdata/conll-corpora",
+                    "domain": "news"
+                },
+                "measure": "F1",
+                "performance": 88.43,
+                "multi_lingual": 87.38,
+                "multi_difference": 1.05
+            },
+            {
+                "name": "TC",
+                "source": "https://github.com/dccuchile/beto",
+                "code": "https://github.com/dccuchile/beto",
+                "dataset": {
+                    "name": "MLDoc",
+                    "link": "https://github.com/facebookresearch/MLDoc",
+                    "domain": "news"
+                },
+                "measure": "Accuracy",
+                "performance": 95.6,
+                "multi_lingual": 95.7,
+                "multi_difference": -0.1
+            },
+            {
+                "name": "PI",
+                "source": "https://github.com/dccuchile/beto",
+                "code": "https://github.com/dccuchile/beto",
+                "dataset": {
+                    "name": "PAWS-X",
+                    "link": "https://github.com/google-research-datasets/paws/tree/master/pawsx",
+                    "domain": "wiki"
+                },
+                "measure": "Accuracy",
+                "performance": 89.05,
+                "multi_lingual": 90.7,
+                "multi_difference": -1.65
+            },
+            {
+                "name": "NLI",
+                "source": "https://github.com/dccuchile/beto",
+                "code": "https://github.com/dccuchile/beto",
+                "dataset": {
+                    "name": "XNLI",
+                    "link": "https://github.com/facebookresearch/XNLI",
+                    "domain": "transcription, politics, news, literature, misc"
+                },
+                "measure": "Accuracy",
+                "performance": 82.01,
+                "multi_lingual": 78.5,
+                "multi_difference": 3.51
+            }
+        ]
+    },
+    {
+        "name": "RuBERT",
+        "language": "Russian",
+        "tasks": [
+            {
+                "source": "https://drive.google.com/open?id=1wAe9MjwQ3QYEtrsiQt0BKL6INQ_J2WAo",
+                "code": NaN,
+                "name": "PI",
+                "dataset": {
+                    "name": "Paraphraser",
+                    "link": "http://paraphraser.ru/download/",
+                    "domain": "news"
+                },
+                "measure": "Accuracy",
+                "performance": 84.99,
+                "multi_lingual": 81.66,
+                "multi_difference": 3.33
+            },
+            {
+                "name": "SA",
+                "source": "https://drive.google.com/open?id=1wAe9MjwQ3QYEtrsiQt0BKL6INQ_J2WAo",
+                "code": NaN,
+                "dataset": {
+                    "name": "RuSentiment",
+                    "link": "http://text-machine.cs.uml.edu/projects/rusentiment/",
+                    "domain": "social"
+                },
+                "measure": "F1",
+                "performance": 72.63,
+                "multi_lingual": 70.82,
+                "multi_difference": 1.81
+            },
+            {
+                "name": "QA",
+                "source": "https://drive.google.com/open?id=1wAe9MjwQ3QYEtrsiQt0BKL6INQ_J2WAo",
+                "code": NaN,
+                "dataset": {
+                    "name": "SDSJ Task B",
+                    "link": "https://sdsj.sberbank.ai/2017/en/contest.html",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (dev)",
+                "performance": 84.6,
+                "multi_lingual": 83.39,
+                "multi_difference": 1.21
+            }
+        ]
+    },
+    {
+        "name": "SlavicBERT",
+        "language": "Slavic",
+        "tasks": [
+            {
+                "source": "https://github.com/deepmipt/Slavic-BERT-NER",
+                "code": "https://github.com/deepmipt/Slavic-BERT-NER",
+                "name": "NER",
+                "dataset": {
+                    "name": "BSNLP-2019 dataset",
+                    "link": "http://bsnlp.cs.helsinki.fi/shared_task.html",
+                    "domain": "web"
+                },
+                "measure": "Recall",
+                "performance": 91.8,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "Ch-RoBERTa-wwm-ext-large",
+        "language": "Chinese",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/1906.08101",
+                "code": "https://github.com/ymcui/Chinese-BERT-wwm",
+                "name": "MRC",
+                "dataset": {
+                    "name": "CMRC 2018",
+                    "link": "https://github.com/ymcui/cmrc2018",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (test)",
+                "performance": 90.0,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "MRC",
+                "source": "https://arxiv.org/abs/1906.08101",
+                "code": "https://github.com/ymcui/Chinese-BERT-wwm",
+                "dataset": {
+                    "name": "DRCD",
+                    "link": "https://github.com/DRCKnowledgeTeam/DRCD",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (test)",
+                "performance": 94.1,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "MRC",
+                "source": "https://arxiv.org/abs/1906.08101",
+                "code": "https://github.com/ymcui/Chinese-BERT-wwm",
+                "dataset": {
+                    "name": "CJRC",
+                    "link": NaN,
+                    "domain": "law"
+                },
+                "measure": "F1 (test)",
+                "performance": 81.0,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "NLI",
+                "source": "https://arxiv.org/abs/1906.08101",
+                "code": "https://github.com/ymcui/Chinese-BERT-wwm",
+                "dataset": {
+                    "name": "XNLI",
+                    "link": "https://github.com/facebookresearch/XNLI",
+                    "domain": "transcription, politics, news, literature, misc"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 80.6,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1906.08101",
+                "code": "https://github.com/ymcui/Chinese-BERT-wwm",
+                "dataset": {
+                    "name": "ChnSentiCorpz",
+                    "link": "https://github.com/pengming617/bert_classification",
+                    "domain": "social, misc"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 94.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SPM",
+                "source": "https://arxiv.org/abs/1906.08101",
+                "code": "https://github.com/ymcui/Chinese-BERT-wwm",
+                "dataset": {
+                    "name": "LCQMC",
+                    "link": "http://icrc.hitsz.edu.cn/Article/show/171.html",
+                    "domain": "social"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 86.8,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SPM",
+                "source": "https://arxiv.org/abs/1906.08101",
+                "code": "https://github.com/ymcui/Chinese-BERT-wwm",
+                "dataset": {
+                    "name": "BQ Corpus",
+                    "link": "http://icrc.hitsz.edu.cn/Article/show/175.html",
+                    "domain": "log"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 84.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "TC",
+                "source": "https://arxiv.org/abs/1906.08101",
+                "code": "https://github.com/ymcui/Chinese-BERT-wwm",
+                "dataset": {
+                    "name": "THUCNews",
+                    "link": "https://github.com/gaussic/text-classification-cnn-rnn",
+                    "domain": "news"
+                },
+                "measure": "Accuracy (test)",
+                "performance": 97.6,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "BERT Japanese",
+        "language": "Japanese",
+        "tasks": [
+            {
+                "source": "https://github.com/yoheikikuta/bert-japanese",
+                "code": "https://github.com/yoheikikuta/bert-japanese",
+                "name": "TC",
+                "dataset": {
+                    "name": "Livedoor",
+                    "link": "https://www.rondhuit.com/download.html",
+                    "domain": "news"
+                },
+                "measure": "F1 (macro)",
+                "performance": 97.0,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "KoBERT",
+        "language": "Korean",
+        "tasks": [
+            {
+                "source": "https://github.com/SKTBrain/KoBERT",
+                "code": "https://github.com/SKTBrain/KoBERT#korean-bert-pre-trained-cased-kobert",
+                "name": "SA",
+                "dataset": {
+                    "name": "Naver",
+                    "link": "https://github.com/e9t/nsmc",
+                    "domain": "movie review"
+                },
+                "measure": "Accuracy",
+                "performance": 90.1,
+                "multi_lingual": 87.5,
+                "multi_difference": 2.6
+            }
+        ]
+    },
+    {
+        "name": "BERT-th",
+        "language": "Thai",
+        "tasks": [
+            {
+                "source": "https://github.com/ThAIKeras/bert",
+                "code": "https://github.com/ThAIKeras/bert",
+                "name": "NLI",
+                "dataset": {
+                    "name": "XNLI",
+                    "link": "https://github.com/facebookresearch/XNLI",
+                    "domain": "transcription, politics, news, literature, misc"
+                },
+                "measure": "Accuracy",
+                "performance": 68.9,
+                "multi_lingual": 66.1,
+                "multi_difference": 2.8
+            },
+            {
+                "name": "SA",
+                "source": "https://github.com/ThAIKeras/bert",
+                "code": "https://github.com/ThAIKeras/bert",
+                "dataset": {
+                    "name": "Wongnai Review Dataset",
+                    "link": "https://github.com/wongnai/wongnai-corpus",
+                    "domain": "restaurant reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 57.06,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "Mongolian BERT",
+        "language": "Mongolian",
+        "tasks": [
+            {
+                "source": "https://github.com/tugstugi/mongolian-bert",
+                "code": "https://github.com/tugstugi/mongolian-bert",
+                "name": "NER",
+                "dataset": {
+                    "name": "Mongolian NER",
+                    "link": "https://github.com/tugstugi/mongolian-nlp/blob/master/datasets/NER_v1.0.json.gz",
+                    "domain": "news"
+                },
+                "measure": "F1 (test)",
+                "performance": 81.46,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "BERTurk",
+        "language": "Turkish",
+        "tasks": [
+            {
+                "source": "https://github.com/stefan-it/turkish-bert",
+                "code": "https://github.com/stefan-it/turkish-bert",
+                "name": "POS",
+                "dataset": {
+                    "name": "IMST dataset",
+                    "link": "https://github.com/UniversalDependencies/UD_Turkish-IMST",
+                    "domain": "misc"
+                },
+                "measure": "Accuracy",
+                "performance": 96.93,
+                "multi_lingual": 95.38,
+                "multi_difference": 1.55
+            },
+            {
+                "name": "NER",
+                "source": "https://github.com/stefan-it/turkish-bert",
+                "code": "https://github.com/stefan-it/turkish-bert",
+                "dataset": {
+                    "name": NaN,
+                    "link": NaN,
+                    "domain": NaN
+                },
+                "measure": "F1",
+                "performance": 94.85,
+                "multi_lingual": 93.61,
+                "multi_difference": 1.24
+            }
+        ]
+    },
+    {
+        "name": "Arabert v1",
+        "language": "Arabic",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/2003.00104",
+                "code": "https://github.com/aub-mind/arabert",
+                "name": "SA",
+                "dataset": {
+                    "name": "AJGT",
+                    "link": "https://github.com/komari6/Arabic-twitter-corpus-AJGT",
+                    "domain": "twitter"
+                },
+                "measure": "Accuracy",
+                "performance": 93.8,
+                "multi_lingual": 83.6,
+                "multi_difference": 10.2
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/2003.00104",
+                "code": "https://github.com/aub-mind/arabert",
+                "dataset": {
+                    "name": "HARD",
+                    "link": "https://github.com/elnagara/HARD-Arabic-Dataset",
+                    "domain": "hotel reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 96.1,
+                "multi_lingual": 95.7,
+                "multi_difference": 0.4
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/2003.00104",
+                "code": "https://github.com/aub-mind/arabert",
+                "dataset": {
+                    "name": "ASTD",
+                    "link": "http://www.mohamedaly.info/datasets/astd",
+                    "domain": "twitter"
+                },
+                "measure": "Accuracy",
+                "performance": 92.6,
+                "multi_lingual": 80.1,
+                "multi_difference": 12.5
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/2003.00104",
+                "code": "https://github.com/aub-mind/arabert",
+                "dataset": {
+                    "name": "ArSenTD-Lev",
+                    "link": "http://www.oma-project.com/",
+                    "domain": "twitter"
+                },
+                "measure": "Accuracy",
+                "performance": 59.4,
+                "multi_lingual": 51.0,
+                "multi_difference": 8.4
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/2003.00104",
+                "code": "https://github.com/aub-mind/arabert",
+                "dataset": {
+                    "name": "LABR",
+                    "link": "https://github.com/mohamedadaly/LABR",
+                    "domain": "book reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 86.7,
+                "multi_lingual": 83.0,
+                "multi_difference": 3.7
+            },
+            {
+                "name": "NER",
+                "source": "https://arxiv.org/abs/2003.00104",
+                "code": "https://github.com/aub-mind/arabert",
+                "dataset": {
+                    "name": "ANER-corp",
+                    "link": "https://github.com/EmnamoR/Arabic-named-entity-recognition",
+                    "domain": "news"
+                },
+                "measure": "F1 (macro)",
+                "performance": 81.9,
+                "multi_lingual": 78.4,
+                "multi_difference": 3.5
+            },
+            {
+                "name": "QA",
+                "source": "https://arxiv.org/abs/2003.00104",
+                "code": "https://github.com/aub-mind/arabert",
+                "dataset": {
+                    "name": "ARCD",
+                    "link": "https://github.com/husseinmozannar/SOQAL",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (macro)",
+                "performance": 62.7,
+                "multi_lingual": 61.3,
+                "multi_difference": 1.4
+            }
+        ]
+    },
+    {
+        "name": "BERT-Large Portuguese",
+        "language": "Portuguese",
+        "tasks": [
+            {
+                "source": "https://github.com/neuralmind-ai/portuguese-bert",
+                "code": "https://github.com/neuralmind-ai/portuguese-bert",
+                "name": "NER",
+                "dataset": {
+                    "name": "Harem",
+                    "link": "https://www.linguateca.pt/HAREM/",
+                    "domain": "web, politics, fiction, email, transcriptions, news, misc"
+                },
+                "measure": "F1 (5 classes)",
+                "performance": 83.3,
+                "multi_lingual": 79.44,
+                "multi_difference": 3.86
+            }
+        ]
+    },
+    {
+        "name": "BERT-Base",
+        "language": "English",
+        "tasks": [
+            {
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "name": "NLI",
+                "dataset": {
+                    "name": "MNLI (matched)",
+                    "link": "http://www.nyu.edu/projects/bowman/multinli/",
+                    "domain": "misc"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 84.6,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "Quora Question Pairs",
+                    "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs",
+                    "domain": "social"
+                },
+                "measure": "F1 (dev)",
+                "performance": 71.2,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "NLI",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "QNLI",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 90.5,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SA",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "Stanford Sentiment Treebank",
+                    "link": "https://nlp.stanford.edu/sentiment/index.html",
+                    "domain": "movie reviews"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 93.5,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "LA",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "CoLA",
+                    "link": "https://nyu-mll.github.io/CoLA/",
+                    "domain": "misc"
+                },
+                "measure": "Matthew's Correlation (dev)",
+                "performance": 52.1,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "STS",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "STS-B",
+                    "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark",
+                    "domain": "misc"
+                },
+                "measure": "Pearson-Spearman Correlation (dev)",
+                "performance": 85.8,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "MRPC",
+                    "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm",
+                    "domain": "news"
+                },
+                "measure": "F1 (dev)",
+                "performance": 88.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "TER",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "RTE",
+                    "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment",
+                    "domain": "news, wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 66.4,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "QA",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "SQuAD v1.1",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (dev)",
+                "performance": 88.5,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "CI",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "SWAG",
+                    "link": "https://rowanzellers.com/swag/",
+                    "domain": "video captions"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 81.6,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "NLI",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "WNLI",
+                    "link": "https://cs.nyu.edu/faculty/davise/papers/WinogradSchemas/WS.html",
+                    "domain": "fiction"
+                },
+                "measure": "Accuracy",
+                "performance": 45.1,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "IMDb",
+                    "link": "https://ai.stanford.edu/~amaas/data/sentiment/",
+                    "domain": "movie reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 93.46,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "BERT-Large",
+        "language": "English",
+        "tasks": [
+            {
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "name": "NLI",
+                "dataset": {
+                    "name": "MNLI (matched)",
+                    "link": "http://www.nyu.edu/projects/bowman/multinli/",
+                    "domain": "misc"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 86.7,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "Quora Question Pairs",
+                    "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs",
+                    "domain": "social"
+                },
+                "measure": "F1 (dev)",
+                "performance": 72.1,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "NLI",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "QNLI",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 92.7,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SA",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "Stanford Sentiment Treebank",
+                    "link": "https://nlp.stanford.edu/sentiment/index.html",
+                    "domain": "movie reviews"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 94.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "LA",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "CoLA",
+                    "link": "https://nyu-mll.github.io/CoLA/",
+                    "domain": "misc"
+                },
+                "measure": "Matthew's Correlation (dev)",
+                "performance": 60.5,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "STS",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "STS-B",
+                    "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark",
+                    "domain": "misc"
+                },
+                "measure": "Pearson-Spearman Correlation (dev)",
+                "performance": 86.5,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "MRPC",
+                    "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm",
+                    "domain": "news"
+                },
+                "measure": "F1 (dev)",
+                "performance": 89.3,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "TER",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "RTE",
+                    "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment",
+                    "domain": "news, wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 70.1,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "QA",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "SQuAD v1.1",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (dev)",
+                "performance": 90.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "QA",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "SQuAD v2.0",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (dev)",
+                "performance": 81.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "CI",
+                "source": "https://www.aclweb.org/anthology/N19-1423.pdf",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "SWAG",
+                    "link": "https://rowanzellers.com/swag/",
+                    "domain": "video captions"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 86.6,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "RC",
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/google-research/bert",
+                "dataset": {
+                    "name": "RACE",
+                    "link": "https://www.cs.cmu.edu/~glai1/data/race/",
+                    "domain": "examinations"
+                },
+                "measure": "Accuracy",
+                "performance": 72.0,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "RoBERTa",
+        "language": "English",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md",
+                "name": "NLI",
+                "dataset": {
+                    "name": "MNLI (matched)",
+                    "link": "http://www.nyu.edu/projects/bowman/multinli/",
+                    "domain": "misc"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 90.2,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md",
+                "dataset": {
+                    "name": "QQP",
+                    "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs",
+                    "domain": "social"
+                },
+                "measure": "F1 (dev)",
+                "performance": 92.2,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "NLI",
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md",
+                "dataset": {
+                    "name": "QNLI",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 94.7,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md",
+                "dataset": {
+                    "name": "Stanford Sentiment Treebank",
+                    "link": "https://nlp.stanford.edu/sentiment/index.html",
+                    "domain": "movie reviews"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 96.4,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "LA",
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md",
+                "dataset": {
+                    "name": "CoLA",
+                    "link": "https://nyu-mll.github.io/CoLA/",
+                    "domain": "misc"
+                },
+                "measure": "Matthew's Correlation (dev)",
+                "performance": 68.0,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "STS",
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md",
+                "dataset": {
+                    "name": "STS-B",
+                    "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark",
+                    "domain": "misc"
+                },
+                "measure": "Pearson-Spearman Correlation (dev)",
+                "performance": 92.4,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md",
+                "dataset": {
+                    "name": "MRPC",
+                    "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm",
+                    "domain": "news"
+                },
+                "measure": "F1 (dev)",
+                "performance": 90.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "TER",
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md",
+                "dataset": {
+                    "name": "RTE",
+                    "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment",
+                    "domain": "news, wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 86.6,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "QA",
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md",
+                "dataset": {
+                    "name": "SQuAD v1.1",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (dev)",
+                "performance": 94.6,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "QA",
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md",
+                "dataset": {
+                    "name": "SQuAD v2.0",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (dev)",
+                "performance": 89.4,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "RC",
+                "source": "https://arxiv.org/abs/1907.11692",
+                "code": "https://github.com/pytorch/fairseq/blob/master/examples/roberta/README.md",
+                "dataset": {
+                    "name": "RACE",
+                    "link": "https://www.cs.cmu.edu/~glai1/data/race/",
+                    "domain": "examinations"
+                },
+                "measure": "Accuracy",
+                "performance": 83.2,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "ALBERT (1M)",
+        "language": "English",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "name": "NLI",
+                "dataset": {
+                    "name": "MNLI (matched)",
+                    "link": "http://www.nyu.edu/projects/bowman/multinli/",
+                    "domain": "misc"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 90.4,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "QQP",
+                    "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs",
+                    "domain": "social"
+                },
+                "measure": "F1 (dev)",
+                "performance": 92.0,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "NLI",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "QNLI",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 95.2,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "Stanford Sentiment Treebank",
+                    "link": "https://nlp.stanford.edu/sentiment/index.html",
+                    "domain": "movie reviews"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 96.8,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "LA",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "CoLA",
+                    "link": "https://nyu-mll.github.io/CoLA/",
+                    "domain": "misc"
+                },
+                "measure": "Matthew's Correlation (dev)",
+                "performance": 68.7,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "STS",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "STS-B",
+                    "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark",
+                    "domain": "misc"
+                },
+                "measure": "Pearson-Spearman Correlation (dev)",
+                "performance": 92.7,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "MRPC",
+                    "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm",
+                    "domain": "news"
+                },
+                "measure": "F1 (dev)",
+                "performance": 90.2,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "TER",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "RTE",
+                    "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment",
+                    "domain": "news, wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 88.1,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "QA",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "SQuAD v1.1",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (dev)",
+                "performance": 94.8,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "QA",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "SQuAD v2.0",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (dev)",
+                "performance": 89.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "RC",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "RACE",
+                    "link": "https://www.cs.cmu.edu/~glai1/data/race/",
+                    "domain": "examinations"
+                },
+                "measure": "Accuracy",
+                "performance": 86.0,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "ALBERT (1.5M)",
+        "language": "English",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "name": "NLI",
+                "dataset": {
+                    "name": "MNLI (matched)",
+                    "link": "http://www.nyu.edu/projects/bowman/multinli/",
+                    "domain": "misc"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 90.8,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "QQP",
+                    "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs",
+                    "domain": "social"
+                },
+                "measure": "F1 (dev)",
+                "performance": 92.2,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "NLI",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "QNLI",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 95.3,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "Stanford Sentiment Treebank",
+                    "link": "https://nlp.stanford.edu/sentiment/index.html",
+                    "domain": "movie reviews"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 96.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "LA",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "CoLA",
+                    "link": "https://nyu-mll.github.io/CoLA/",
+                    "domain": "misc"
+                },
+                "measure": "Matthew's Correlation (dev)",
+                "performance": 71.4,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "STS",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "STS-B",
+                    "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark",
+                    "domain": "misc"
+                },
+                "measure": "Pearson-Spearman Correlation (dev)",
+                "performance": 93.0,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "MRPC",
+                    "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm",
+                    "domain": "news"
+                },
+                "measure": "F1 (dev)",
+                "performance": 90.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "TER",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "RTE",
+                    "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment",
+                    "domain": "news, wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 89.2,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "QA",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "SQuAD v1.1",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (dev)",
+                "performance": 94.8,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "QA",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "SQuAD v2.0",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (dev)",
+                "performance": 90.2,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "RC",
+                "source": "https://arxiv.org/abs/1909.11942",
+                "code": "https://github.com/google-research/ALBERT",
+                "dataset": {
+                    "name": "RACE",
+                    "link": "https://www.cs.cmu.edu/~glai1/data/race/",
+                    "domain": "examinations"
+                },
+                "measure": "Accuracy",
+                "performance": 86.5,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "DistilBERT",
+        "language": "English",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation",
+                "name": "NLI",
+                "dataset": {
+                    "name": "MNLI (matched)",
+                    "link": "http://www.nyu.edu/projects/bowman/multinli/",
+                    "domain": "misc"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 79.0,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation",
+                "dataset": {
+                    "name": "QQP",
+                    "link": "https://www.quora.com/q/quoradata/First-Quora-Dataset-Release-Question-Pairs",
+                    "domain": "social"
+                },
+                "measure": "F1 (dev)",
+                "performance": 84.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "NLI",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation",
+                "dataset": {
+                    "name": "QNLI",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 85.3,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation",
+                "dataset": {
+                    "name": "Stanford Sentiment Treebank",
+                    "link": "https://nlp.stanford.edu/sentiment/index.html",
+                    "domain": "movie reviews"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 90.7,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "LA",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation",
+                "dataset": {
+                    "name": "CoLA",
+                    "link": "https://nyu-mll.github.io/CoLA/",
+                    "domain": "misc"
+                },
+                "measure": "Matthew's Correlation (dev)",
+                "performance": 43.6,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "STS",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation",
+                "dataset": {
+                    "name": "STS-B",
+                    "link": "http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark",
+                    "domain": "misc"
+                },
+                "measure": "Pearson-Spearman Correlation (dev)",
+                "performance": 81.2,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "PI",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation",
+                "dataset": {
+                    "name": "MRPC",
+                    "link": "http://research.microsoft.com/research/nlp/msr_paraphrase.htm",
+                    "domain": "news"
+                },
+                "measure": "F1 (dev)",
+                "performance": 87.5,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "TER",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation",
+                "dataset": {
+                    "name": "RTE",
+                    "link": "https://aclweb.org/aclwiki/Recognizing_Textual_Entailment",
+                    "domain": "news, wiki"
+                },
+                "measure": "Accuracy (dev)",
+                "performance": 59.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "QA",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation",
+                "dataset": {
+                    "name": "SQuAD v1.1",
+                    "link": "https://rajpurkar.github.io/SQuAD-explorer/",
+                    "domain": "wiki"
+                },
+                "measure": "F1 (dev)",
+                "performance": 78.7,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "NLI",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation",
+                "dataset": {
+                    "name": "WNLI",
+                    "link": "https://cs.nyu.edu/faculty/davise/papers/WinogradSchemas/WS.html",
+                    "domain": "fiction"
+                },
+                "measure": "Accuracy",
+                "performance": 56.3,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/abs/1910.01108",
+                "code": "https://github.com/huggingface/transformers/tree/master/examples/distillation",
+                "dataset": {
+                    "name": "IMDb",
+                    "link": "https://ai.stanford.edu/~amaas/data/sentiment/",
+                    "domain": "movie reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 92.82,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "Fine-Tuned mBERT",
+        "language": "Yor\u00f9b\u00e1",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/abs/1912.02481",
+                "code": "https://github.com/ajesujoba/YorubaTwi-Embedding",
+                "name": "NER",
+                "dataset": {
+                    "name": "Global Voices Yor\u00f9b\u00e1",
+                    "link": "https://yo.globalvoices.org/",
+                    "domain": "news"
+                },
+                "measure": "F1",
+                "performance": 52.5,
+                "multi_lingual": 0.0,
+                "multi_difference": 52.5
+            }
+        ]
+    },
+    {
+        "name": "BERT-Tagalog",
+        "language": "Philipino",
+        "tasks": [
+            {
+                "source": "https://arxiv.org/pdf/1907.00409.pdf",
+                "code": "https://github.com/jcblaisecruz02/Tagalog-BERT",
+                "name": "SA",
+                "dataset": {
+                    "name": "-",
+                    "link": "-",
+                    "domain": "electronic products reviews"
+                },
+                "measure": "Accuracy",
+                "performance": 88.17,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    }
+]

--- a/static/data/data_example.json
+++ b/static/data/data_example.json
@@ -1208,6 +1208,62 @@
                 "performance": 82.01,
                 "multi_lingual": 78.5,
                 "multi_difference": 3.51
+            },
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "TASS 2020",
+                    "link": "http://tass.sepln.org/2020/",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 66.5,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "Emotion Analysis",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "TASS 2020",
+                    "link": "http://tass.sepln.org/2020/",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 52.1,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "Hate Speech Detection",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "SemEval 2019 Task 5: HatEval",
+                    "link": "https://competitions.codalab.org/competitions/19935",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 76.8,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "ID",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "SemEval 2019 Task 5: HatEval",
+                    "link": "https://www.autoritas.net/IroSvA2019/",
+                    "domain": "social media"
+                },
+                "measure": "F1 (test)",
+                "performance": 70.6,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
             }
         ]
     },
@@ -2672,6 +2728,192 @@
                 },
                 "measure": "Accuracy",
                 "performance": 88.17,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "RoBERTuito",
+        "language": "Spanish",
+        "tasks": [
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "TASS 2020",
+                    "link": "http://tass.sepln.org/2020/",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 70.07,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "Emotion Analysis",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "TASS 2020",
+                    "link": "http://tass.sepln.org/2020/",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 55.1,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "Hate Speech Detection",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "SemEval 2019 Task 5: HatEval",
+                    "link": "https://competitions.codalab.org/competitions/19935",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 80.1,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "ID",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "SemEval 2019 Task 5: HatEval",
+                    "link": "https://www.autoritas.net/IroSvA2019/",
+                    "domain": "social media"
+                },
+                "measure": "F1 (test)",
+                "performance": 74.0,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "Spanish RoBERTa",
+        "language": "Spanish",
+        "tasks": [
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "TASS 2020",
+                    "link": "http://tass.sepln.org/2020/",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 66.9,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "Emotion Analysis",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "TASS 2020",
+                    "link": "http://tass.sepln.org/2020/",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 53.3,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "Hate Speech Detection",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "SemEval 2019 Task 5: HatEval",
+                    "link": "https://competitions.codalab.org/competitions/19935",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 76.6,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "ID",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "SemEval 2019 Task 5: HatEval",
+                    "link": "https://www.autoritas.net/IroSvA2019/",
+                    "domain": "social media"
+                },
+                "measure": "F1 (test)",
+                "performance": 72.3,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            }
+        ]
+    },
+    {
+        "name": "BERTin",
+        "language": "Spanish",
+        "tasks": [
+            {
+                "name": "SA",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "TASS 2020",
+                    "link": "http://tass.sepln.org/2020/",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 66.5,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "Emotion Analysis",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "TASS 2020",
+                    "link": "http://tass.sepln.org/2020/",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 51.8,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "Hate Speech Detection",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "SemEval 2019 Task 5: HatEval",
+                    "link": "https://competitions.codalab.org/competitions/19935",
+                    "domain": "twitter"
+                },
+                "measure": "F1 (test)",
+                "performance": 76.7,
+                "multi_lingual": "nan",
+                "multi_difference": "nan"
+            },
+            {
+                "name": "ID",
+                "source": "https://arxiv.org/pdf/2111.09453.pdf",
+                "code": "https://github.com/pysentimiento/robertuito",
+                "dataset": {
+                    "name": "SemEval 2019 Task 5: HatEval",
+                    "link": "https://www.autoritas.net/IroSvA2019/",
+                    "domain": "social media"
+                },
+                "measure": "F1 (test)",
+                "performance": 71.6,
                 "multi_lingual": "nan",
                 "multi_difference": "nan"
             }


### PR DESCRIPTION
- Adds performances for Social Media tasks in Spanish: Sentiment analysis, Emotion analysis, Hate Speech detection, Irony detection. Considered models are:
  * [BETO](https://huggingface.co/dccuchile/bert-base-spanish-wwm-cased/)
  * [Spanish RoBERTa](https://huggingface.co/PlanTL-GOB-ES/roberta-large-bne)
  * [RoBERTuito](https://huggingface.co/pysentimiento/robertuito-base-uncased)
- Indents json file for better reading 